### PR TITLE
:arrow_up: Bump FPU to v0.5.1

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -47,7 +47,7 @@ timer_unit:
 common_cells:
   commit: df60199539995b8dba7a598ae10b57e361968845
 fpnew:
-  commit: tags/pulpissimov1.0.0
+  commit: v0.5.1
 jtag_pulp:
   commit: dbg_dev
 riscv:


### PR DESCRIPTION
Update the FPU to the release version, including some bugfixes and documentation