### PR TITLE
Fix xcelium

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -51,9 +51,9 @@ fpnew:
 jtag_pulp:
   commit: dbg_dev
 riscv:
-  commit: tags/pulpissimo-v3.3.0
-zero-riscy:
-  commit: tags/pulpissimo-v1.0.1
+  commit: 8d2bddaff52b6b31c54696a3d966a6b4de4d3b97
+# zero-riscy:
+#   commit: tags/pulpissimo-v1.0.1
 scm:
   commit: tags/pulpissimo-v1.0
 generic_FLL:

--- a/rtl/components/axi_slice_dc_slave_wrap.sv
+++ b/rtl/components/axi_slice_dc_slave_wrap.sv
@@ -154,6 +154,7 @@ module axi_slice_dc_slave_wrap
       .axi_master_b_readpointer(axi_master_async.b_readpointer)
     );
 
+/*
 `ifndef SYNTHESIS
 
     Axi4PC #(
@@ -218,5 +219,5 @@ module axi_slice_dc_slave_wrap
     );
 
 `endif
-
+*/
 endmodule

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -224,46 +224,46 @@ module fc_subsystem #(
         .fregfile_disable_i    ( 1'b0              ) // try me!
     );
     end else begin: FC_CORE
-    zeroriscy_core #(
-        .N_EXT_PERF_COUNTERS ( N_EXT_PERF_COUNTERS ),
-        .RV32E               ( ZERORISCY_RV32E     ),
-        .RV32M               ( ZERORISCY_RV32M     )
-    ) lFC_CORE (
-        .clk_i                 ( clk_i             ),
-        .rst_ni                ( rst_ni            ),
-        .clock_en_i            ( core_clock_en     ),
-        .test_en_i             ( test_en_i         ),
-        .boot_addr_i           ( boot_addr_i       ),
-        .core_id_i             ( CORE_ID           ),
-        .cluster_id_i          ( CLUSTER_ID        ),
+    // zeroriscy_core #(
+    //     .N_EXT_PERF_COUNTERS ( N_EXT_PERF_COUNTERS ),
+    //     .RV32E               ( ZERORISCY_RV32E     ),
+    //     .RV32M               ( ZERORISCY_RV32M     )
+    // ) lFC_CORE (
+    //     .clk_i                 ( clk_i             ),
+    //     .rst_ni                ( rst_ni            ),
+    //     .clock_en_i            ( core_clock_en     ),
+    //     .test_en_i             ( test_en_i         ),
+    //     .boot_addr_i           ( boot_addr_i       ),
+    //     .core_id_i             ( CORE_ID           ),
+    //     .cluster_id_i          ( CLUSTER_ID        ),
 
-        // Instruction Memory Interface:  Interface to Instruction Logaritmic interconnect: Req->grant handshake
-        .instr_addr_o          ( core_instr_addr   ),
-        .instr_req_o           ( core_instr_req    ),
-        .instr_rdata_i         ( core_instr_rdata  ),
-        .instr_gnt_i           ( core_instr_gnt    ),
-        .instr_rvalid_i        ( core_instr_rvalid ),
+    //     // Instruction Memory Interface:  Interface to Instruction Logaritmic interconnect: Req->grant handshake
+    //     .instr_addr_o          ( core_instr_addr   ),
+    //     .instr_req_o           ( core_instr_req    ),
+    //     .instr_rdata_i         ( core_instr_rdata  ),
+    //     .instr_gnt_i           ( core_instr_gnt    ),
+    //     .instr_rvalid_i        ( core_instr_rvalid ),
 
-        // Data memory interface:
-        .data_addr_o           ( core_data_addr    ),
-        .data_req_o            ( core_data_req     ),
-        .data_be_o             ( core_data_be      ),
-        .data_rdata_i          ( core_data_rdata   ),
-        .data_we_o             ( core_data_we      ),
-        .data_gnt_i            ( core_data_gnt     ),
-        .data_wdata_o          ( core_data_wdata   ),
-        .data_rvalid_i         ( core_data_rvalid  ),
+    //     // Data memory interface:
+    //     .data_addr_o           ( core_data_addr    ),
+    //     .data_req_o            ( core_data_req     ),
+    //     .data_be_o             ( core_data_be      ),
+    //     .data_rdata_i          ( core_data_rdata   ),
+    //     .data_we_o             ( core_data_we      ),
+    //     .data_gnt_i            ( core_data_gnt     ),
+    //     .data_wdata_o          ( core_data_wdata   ),
+    //     .data_rvalid_i         ( core_data_rvalid  ),
 
-        .irq_i                 ( core_irq_req      ),
-        .irq_id_i              ( core_irq_id       ),
-        .irq_ack_o             ( core_irq_ack      ),
-        .irq_id_o              ( core_irq_ack_id   ),
+    //     .irq_i                 ( core_irq_req      ),
+    //     .irq_id_i              ( core_irq_id       ),
+    //     .irq_ack_o             ( core_irq_ack      ),
+    //     .irq_id_o              ( core_irq_ack_id   ),
 
-        .debug_req_i           ( debug_req_i       ),
+    //     .debug_req_i           ( debug_req_i       ),
 
-        .fetch_enable_i        ( fetch_en_int      ),
-        .ext_perf_counters_i   ( perf_counters_int )
-    );
+    //     .fetch_enable_i        ( fetch_en_int      ),
+    //     .ext_perf_counters_i   ( perf_counters_int )
+    // );
     end
     endgenerate
 

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -463,7 +463,7 @@ module pulp_soc #(
     ) dc_fifo_datain_bus_i (
         .clk_i            ( s_soc_clk               ),
         .rst_ni           ( s_rstn_cluster_sync_soc ),
-        .test_cgbypass_i  ( 1'b0                    ),
+        // .test_cgbypass_i  ( 1'b0                    ),
         .isolate_i        ( s_cluster_isolate_dc    ),
         .axi_slave        ( s_data_out_bus          ),
         .axi_master_async ( s_data_master           )


### PR DESCRIPTION
This fixes some issue where xcelium chokes on:
* Update RI5CY to fixed version (circumenventing parser issues in tb)
* Axi4PC doesn't exist
* zero-riscy doesn't work in the current configuration (new debug unit/interface)
* test_cgbypass_i doesn't exist in local IP