### PR TITLE
Switch from Zero-riscy to Ibex

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -52,8 +52,8 @@ jtag_pulp:
   commit: dbg_dev
 riscv:
   commit: 8d2bddaff52b6b31c54696a3d966a6b4de4d3b97
-# zero-riscy:
-#   commit: tags/pulpissimo-v1.0.1
+zero-riscy:
+  commit: pulpissimo
 scm:
   commit: 300c13879d3b6e28782e14fd466a7c09c875a031
 generic_FLL:

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -53,7 +53,7 @@ jtag_pulp:
 riscv:
   commit: pulpissimo-v3.3.1
 ibex:
-  commit: pulpissimo
+  commit: 13313952cd50ff04489f6cf3dba9ba05c2011a8b
   group: lowRISC
 scm:
   commit: 300c13879d3b6e28782e14fd466a7c09c875a031

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -52,8 +52,9 @@ jtag_pulp:
   commit: dbg_dev
 riscv:
   commit: 8d2bddaff52b6b31c54696a3d966a6b4de4d3b97
-zero-riscy:
+ibex:
   commit: pulpissimo
+  group: lowRISC
 scm:
   commit: 300c13879d3b6e28782e14fd466a7c09c875a031
 generic_FLL:

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -515,6 +515,7 @@ module pulp_soc
     //********************************************************
 
     soc_peripherals #(
+        .CORE_TYPE          ( CORE_TYPE                             ),
         .MEM_ADDR_WIDTH     ( L2_MEM_ADDR_WIDTH+$clog2(NB_L2_BANKS) ),
         .APB_ADDR_WIDTH     ( 32                                    ),
         .APB_DATA_WIDTH     ( 32                                    ),

--- a/rtl/pulp_soc/soc_peripherals.sv
+++ b/rtl/pulp_soc/soc_peripherals.sv
@@ -11,6 +11,7 @@
 `include "pulp_soc_defines.sv"
 
 module soc_peripherals #(
+    parameter CORE_TYPE      = 0,
     parameter MEM_ADDR_WIDTH = 13,
     parameter APB_ADDR_WIDTH = 32,
     parameter APB_DATA_WIDTH = 32,
@@ -145,6 +146,7 @@ module soc_peripherals #(
     output logic                       cluster_irq_o
 );
 
+    localparam USE_IBEX = CORE_TYPE == 1 || CORE_TYPE == 2;
 
     APB_BUS s_fll_bus ();
 
@@ -196,6 +198,8 @@ module soc_peripherals #(
     assign s_events[141]              = fc_hwpe_events_i[1];
     assign s_events[159:142]          = '0;
 
+    generate
+    if ( USE_IBEX == 0) begin: FC_EVENTS
     assign fc_events_o[7:0] = 8'h0; //RESERVED for sw events
     assign fc_events_o[8]   = dma_pe_evt_i;
     assign fc_events_o[9]   = dma_pe_irq_i;
@@ -221,6 +225,25 @@ module soc_peripherals #(
     assign fc_events_o[29]  = s_fc_err_events;
     assign fc_events_o[30]  = s_fc_hp_events[0];
     assign fc_events_o[31]  = s_fc_hp_events[1];
+    end else begin : FC_EVENTS
+    assign fc_events_o[0]     = s_timer_lo_event;
+    assign fc_events_o[1]     = s_timer_hi_event;
+    assign fc_events_o[2]     = s_ref_rise_event | s_ref_fall_event;
+    assign fc_events_o[3]     = s_gpio_event;
+    assign fc_events_o[4]     = s_adv_timer_events[0];
+    assign fc_events_o[5]     = s_adv_timer_events[1];
+    assign fc_events_o[6]     = s_adv_timer_events[2];
+    assign fc_events_o[7]     = s_adv_timer_events[3];
+    assign fc_events_o[8]     = 1'b0; // not used
+    assign fc_events_o[9]     = 1'b0; // not used
+    assign fc_events_o[10]    = 1'b0; //RESERVED for soc event FIFO
+    assign fc_events_o[11]    = s_fc_err_events;
+    assign fc_events_o[12]    = s_fc_hp_events[0];
+    assign fc_events_o[13]    = s_fc_hp_events[1];
+    assign fc_events_o[14]    = 1'b0; // not used
+    assign fc_events_o[31:15] = 17'b0; // not supported by Ibex
+    end
+    endgenerate
 
     pulp_sync_wedge i_ref_clk_sync (
         .clk_i    ( clk_i            ),


### PR DESCRIPTION
This PR switches from Zero-riscy to Ibex. Besides switching to a newer version of the upstream IP, this also requires changes in the interrupt framework and boot address alignment. Both these changes are only conditionally enabled if Ibex is selected.
 