### PR TITLE
s_rstn_cluster_sync typo fix

### DIFF
--- a/rtl/pulp_soc/soc_clk_rst_gen.sv
+++ b/rtl/pulp_soc/soc_clk_rst_gen.sv
@@ -246,7 +246,7 @@ module soc_clk_rst_gen (
             .init_no     (                     )                    //not used
         );
     `else
-        assign s_rstn_soc_sync = s_rstn_soc;
+        assign s_rstn_cluster_sync = s_rstn_soc;
     `endif
 
     assign clk_soc_o       = s_clk_soc;


### PR DESCRIPTION
Correct me if I'm wrong, but I believe there should be `s_rstn_cluster_sync` instead of `s_rstn_soc_sync`, which is assigned above.