### PR TITLE
Pulp next

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -42,8 +42,6 @@ axi/axi_slice:
   commit: v1.1.4
 axi/axi_slice_dc:
   commit: v1.1.3
-axi/axi_mem_if:
-  commit: v0.2.0
 timer_unit:
   commit: v1.0.2
 common_cells:

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -20,66 +20,98 @@
 
 L2_tcdm_hybrid_interco:
   commit: pulpissimo-v1.0
+  domain: [soc]
 adv_dbg_if:
   commit: v0.0.1
+  domain: [cluster, soc]
 apb/apb2per:
   commit: v0.0.1
+  domain: [soc]
 apb/apb_adv_timer:
   commit: v1.0.2
+  domain: [soc]
 apb/apb_fll_if:
   commit: pulpissimo-v1.0
+  domain: [soc]
 apb/apb_gpio:
   commit: v0.2.0
+  domain: [soc]
 apb/apb_node:
   commit: v0.1.1
+  domain: [soc]
 apb_interrupt_cntrl:
   commit: v0.0.1
+  domain: [soc]
 axi/axi:
   commit: v0.7.1
+  domain: [soc]
 axi/axi_node:
   commit: v1.1.4
+  domain: [cluster, soc]
 axi/axi_slice:
   commit: v1.1.4
+  domain: [cluster, soc]
 axi/axi_slice_dc:
   commit: v1.1.3
+  domain: [cluster, soc]
 timer_unit:
   commit: v1.0.2
+  domain: [cluster, soc]
 common_cells:
   commit: v1.13.1
+  domain: [cluster, soc]
 fpnew:
   commit: v0.6.1
+  domain: [cluster, soc]
 jtag_pulp:
   commit: v0.1
+  domain: [soc]
 riscv:
   commit: pulpissimo-v3.4.0
+  domain: [cluster, soc]
 ibex:
   commit: 13313952cd50ff04489f6cf3dba9ba05c2011a8b
   group: lowRISC
+  domain: [soc]
 scm:
   commit: v1.0.1
+  domain: [cluster, soc]
 generic_FLL:
   commit: v0.1
+  domain: [soc]
 tech_cells_generic:
   commit: v0.1.6
+  domain: [cluster, soc]
 udma/udma_core:
   commit: v1.0.0
+  domain: [soc]
 udma/udma_uart:
   commit: v1.0.0
+  domain: [soc]
 udma/udma_i2c:
   commit: vega_v1.0.0
+  domain: [soc]
 udma/udma_i2s:
   commit: v1.0.0
+  domain: [soc]
 udma/udma_qspi:
   commit: v1.0.0
+  domain: [soc]
 udma/udma_sdio:
   commit: vega_v1.0.5
+  domain: [soc]
 udma/udma_camera:
   commit: v1.0.0
+  domain: [soc]
 udma/udma_filter:
   commit: v1.0.0
+  domain: [soc]
 udma/udma_external_per:
   commit: v1.0.0
+  domain: [soc]
 hwpe-mac-engine:
   commit: v1.2
+  domain: [cluster, soc]
 riscv-dbg:
   commit: v0.2
+  domain: [soc]

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -44,7 +44,7 @@ apb_interrupt_cntrl:
   domain: [soc]
 axi/axi:
   commit: v0.7.1
-  domain: [soc]
+  domain: [cluster, soc]
 axi/axi_node:
   commit: v1.1.4
   domain: [cluster, soc]

--- a/rtl/components/pulp_interfaces.sv
+++ b/rtl/components/pulp_interfaces.sv
@@ -360,7 +360,7 @@ interface BBMUX_CONFIG_BUS;
 
 endinterface // BBMUX_CONFIG_BUS
 
-interface AXI_BUS
+interface AXI_BUS2
 #(
    parameter AXI_ADDR_WIDTH = 32,
    parameter AXI_DATA_WIDTH = 64,
@@ -473,7 +473,7 @@ interface AXI_BUS
 
 endinterface
 
-interface AXI_BUS_ASYNC
+interface AXI_BUS_ASYNC2
       #(
       parameter AXI_ADDR_WIDTH = 32,
       parameter AXI_DATA_WIDTH = 64,

--- a/rtl/components/pulp_interfaces.sv
+++ b/rtl/components/pulp_interfaces.sv
@@ -848,9 +848,15 @@ interface SP_ICACHE_CTRL_UNIT_BUS;
     logic                 ctrl_req_disable;
     logic                 ctrl_ack_disable;
     logic                 ctrl_pending_trans;
-    logic                 flush_req;
-    logic                 flush_ack;
+    logic                 ctrl_flush_req;
+    logic                 ctrl_flush_ack;
     logic                 icache_is_private;
+
+
+    logic                 sel_flush_req;
+    logic [31:0]          sel_flush_addr;
+    logic                 sel_flush_ack;
+
 `ifdef FEATURE_ICACHE_STAT
     logic [31:0]          ctrl_hit_count;
     logic [31:0]          ctrl_trans_count;
@@ -867,13 +873,18 @@ interface SP_ICACHE_CTRL_UNIT_BUS;
     (
         output ctrl_req_enable,
         output ctrl_req_disable,
-        output flush_req,
+        output ctrl_flush_req,
         output icache_is_private,
-        input  flush_ack,
 
+        input  ctrl_flush_ack,
         input  ctrl_ack_enable,
         input  ctrl_ack_disable,
-        input  ctrl_pending_trans
+        input  ctrl_pending_trans,
+
+        output        sel_flush_req,
+        output        sel_flush_addr,
+        input         sel_flush_ack
+
     `ifdef FEATURE_ICACHE_STAT
         ,
         input  ctrl_hit_count,
@@ -890,13 +901,18 @@ interface SP_ICACHE_CTRL_UNIT_BUS;
     (
         input  ctrl_req_enable,
         input  ctrl_req_disable,
-        input  flush_req,
+        input  ctrl_flush_req,
         input  icache_is_private,
-        output flush_ack,
 
+        output ctrl_flush_ack,
         output ctrl_ack_enable,
         output ctrl_ack_disable,
-        output ctrl_pending_trans
+        output ctrl_pending_trans,
+
+        input        sel_flush_req,
+        input        sel_flush_addr,
+        output       sel_flush_ack
+
     `ifdef FEATURE_ICACHE_STAT
         ,
         output ctrl_hit_count,
@@ -1114,10 +1130,16 @@ interface PRI_ICACHE_CTRL_UNIT_BUS;
     logic                 flush_req;
     logic                 flush_ack;
 
+    logic                 sel_flush_req;
+    logic [31:0]          sel_flush_addr;
+    logic                 sel_flush_ack;
+
 `ifdef FEATURE_ICACHE_STAT
     logic [31:0]          ctrl_hit_count;
     logic [31:0]          ctrl_trans_count;
     logic [31:0]          ctrl_miss_count;
+    logic [31:0]          ctrl_cong_count;
+
     logic                 ctrl_clear_regs;
     logic                 ctrl_enable_regs;
 `endif
@@ -1129,13 +1151,19 @@ interface PRI_ICACHE_CTRL_UNIT_BUS;
         output bypass_req,
         output flush_req,
         input  bypass_ack,
-        input  flush_ack
+        input  flush_ack,
+
+        output sel_flush_req,
+        output sel_flush_addr,
+        input  sel_flush_ack
 
     `ifdef FEATURE_ICACHE_STAT
         ,
         input  ctrl_hit_count,
         input  ctrl_trans_count,
         input  ctrl_miss_count,
+        input  ctrl_cong_count,
+
         output ctrl_clear_regs,
         output ctrl_enable_regs
     `endif
@@ -1148,12 +1176,19 @@ interface PRI_ICACHE_CTRL_UNIT_BUS;
         input  bypass_req,
         input  flush_req,
         output bypass_ack,
-        output flush_ack
+        output flush_ack,
+
+        input  sel_flush_req,
+        input  sel_flush_addr,
+        output sel_flush_ack
+
     `ifdef FEATURE_ICACHE_STAT
         ,
         output ctrl_hit_count,
         output ctrl_trans_count,
         output ctrl_miss_count,
+        output ctrl_cong_count,
+
         input  ctrl_clear_regs,
         input  ctrl_enable_regs
     `endif

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -29,6 +29,7 @@ module pulp_soc
     parameter AXI_STRB_WIDTH_OUT = AXI_DATA_OUT_WIDTH/8,
     parameter BUFFER_WIDTH       = 8,
     parameter EVNT_WIDTH         = 8,
+    parameter NB_CORES           = 8,
     parameter NB_HWPE_PORTS      = 4,
     parameter NGPIO              = 43,
     parameter NPAD               = 64,
@@ -230,7 +231,7 @@ module pulp_soc
     input  logic                          jtag_tms_i,
     input  logic                          jtag_tdi_i,
     output logic                          jtag_tdo_o,
-    output logic [`NB_CORES-1:0]          cluster_dbg_irq_valid_o
+    output logic [NB_CORES-1:0]          cluster_dbg_irq_valid_o
     ///////////////////////////////////////////////////
 );
 
@@ -273,9 +274,9 @@ module pulp_soc
     */
 
     localparam NrHarts                               = 1024;
-    localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = 1 << FC_Core_MHARTID | (1 << CL_Core0_MHARTID) | (1 << CL_Core1_MHARTID) | (1 << CL_Core2_MHARTID) | (1 << CL_Core3_MHARTID) | (1 << CL_Core4_MHARTID) | (1 << CL_Core5_MHARTID) | (1 << CL_Core6_MHARTID) | (1 << CL_Core7_MHARTID);
+    localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = (1 << FC_Core_MHARTID) | (1 << CL_Core0_MHARTID) | (1 << CL_Core1_MHARTID) | (1 << CL_Core2_MHARTID) | (1 << CL_Core3_MHARTID) | (1 << CL_Core4_MHARTID) | (1 << CL_Core5_MHARTID) | (1 << CL_Core6_MHARTID) | (1 << CL_Core7_MHARTID);
 
-    logic [`NB_CORES-1:0]   CLUSTER_CORE_ID;
+    logic [NB_CORES-1:0][10:0]   CLUSTER_CORE_ID;
 
     assign CLUSTER_CORE_ID[0] = CL_Core0_MHARTID;
     assign CLUSTER_CORE_ID[1] = CL_Core1_MHARTID;
@@ -553,7 +554,7 @@ module pulp_soc
         .MEM_ADDR_WIDTH     ( L2_MEM_ADDR_WIDTH+$clog2(NB_L2_BANKS) ),
         .APB_ADDR_WIDTH     ( 32                                    ),
         .APB_DATA_WIDTH     ( 32                                    ),
-        .NB_CORES           ( `NB_CORES                             ),
+        .NB_CORES           ( NB_CORES                              ),
         .NB_CLUSTERS        ( `NB_CLUSTERS                          ),
         .EVNT_WIDTH         ( EVNT_WIDTH                            ),
         .NGPIO              ( NGPIO                                 ),
@@ -869,7 +870,7 @@ module pulp_soc
    endgenerate
    
    generate
-      for(dbg_var=0;dbg_var<`NB_CORES;dbg_var=dbg_var+1)
+      for(dbg_var=0;dbg_var<NB_CORES;dbg_var=dbg_var+1)
         assign cluster_dbg_irq_valid_o[dbg_var] = dm_debug_req[CLUSTER_CORE_ID[dbg_var]];
    endgenerate
    

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -706,7 +706,7 @@ module pulp_soc
         .ack_o   ( dma_pe_irq_ack_o        ),
         .valid_i ( dma_pe_irq_valid_i      )
     );
-
+`ifndef PULP_FPGA_EMUL
     edge_propagator_rx ep_pf_evt_i (
         .clk_i   ( s_soc_clk               ),
         .rstn_i  ( s_rstn_cluster_sync_soc ),
@@ -714,7 +714,7 @@ module pulp_soc
         .ack_o   ( pf_evt_ack_o            ),
         .valid_i ( pf_evt_valid_i          )
     );
-
+`endif
 
     fc_subsystem #(
         .CORE_TYPE  ( CORE_TYPE          ),

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -386,7 +386,7 @@ module pulp_soc
         .AXI_DATA_WIDTH ( AXI_DATA_OUT_WIDTH ),
         .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH   ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH     ),
-        .BUFFER_WIDTH   ( BUFFER_WIDTH      
+        .BUFFER_WIDTH   ( BUFFER_WIDTH       )
     ) s_data_master ();
 
     AXI_BUS_ASYNC #(
@@ -394,7 +394,7 @@ module pulp_soc
         .AXI_DATA_WIDTH ( AXI_DATA_IN_WIDTH ),
         .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH  ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH     ),
-        .BUFFER_WIDTH   ( BUFFER_WIDTH      
+        .BUFFER_WIDTH   ( BUFFER_WIDTH       )
     ) s_data_slave ();
 
     AXI_BUS #(

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -227,9 +227,12 @@ module pulp_soc
     input  logic                          jtag_trst_ni,
     input  logic                          jtag_tms_i,
     input  logic                          jtag_tdi_i,
-    output logic                          jtag_tdo_o
+    output logic                          jtag_tdo_o,
+    output logic [`NB_CORES-1:0]          cluster_dbg_irq_valid_o
     ///////////////////////////////////////////////////
 );
+
+    genvar dbg_var, nhart_var;
 
     localparam FLL_ADDR_WIDTH        = 32;
     localparam FLL_DATA_WIDTH        = 32;
@@ -240,9 +243,20 @@ module pulp_soc
     localparam L2_BANK_SIZE_PRI      = 8192;             // in 32-bit words
     localparam L2_MEM_ADDR_WIDTH_PRI = $clog2(L2_BANK_SIZE_PRI * NB_L2_BANKS_PRI) - $clog2(NB_L2_BANKS_PRI);
     localparam ROM_ADDR_WIDTH        = 13;
+   
     localparam FC_Core_CLUSTER_ID    = 6'd31;
+    localparam CL_Core_CLUSTER_ID    = 6'd0;
+   
     localparam FC_Core_CORE_ID       = 4'd0;
     localparam FC_Core_MHARTID       = {FC_Core_CLUSTER_ID,1'b0,FC_Core_CORE_ID};
+    localparam CL_Core0_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd0};
+    localparam CL_Core1_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd1};
+    localparam CL_Core2_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd2};
+    localparam CL_Core3_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd3};
+    localparam CL_Core4_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd4};
+    localparam CL_Core5_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd5};
+    localparam CL_Core6_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd6};
+    localparam CL_Core7_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd7};
 
     /*
         PULP RISC-V cores have not continguos MHARTID.
@@ -257,7 +271,20 @@ module pulp_soc
     */
 
     localparam NrHarts                               = 1024;
-    localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = 1 << FC_Core_MHARTID;
+    localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = 1 << FC_Core_MHARTID | (1 << CL_Core0_MHARTID) | (1 << CL_Core1_MHARTID) | (1 << CL_Core2_MHARTID) | (1 << CL_Core3_MHARTID) | (1 << CL_Core4_MHARTID) | (1 << CL_Core5_MHARTID) | (1 << CL_Core6_MHARTID) | (1 << CL_Core7_MHARTID);
+
+    logic [`NB_CORES-1:0]   CLUSTER_CORE_ID;
+
+    assign CLUSTER_CORE_ID[0] = CL_Core0_MHARTID;
+    assign CLUSTER_CORE_ID[1] = CL_Core1_MHARTID;
+    assign CLUSTER_CORE_ID[2] = CL_Core2_MHARTID;
+    assign CLUSTER_CORE_ID[3] = CL_Core3_MHARTID;
+    assign CLUSTER_CORE_ID[4] = CL_Core4_MHARTID;
+    assign CLUSTER_CORE_ID[5] = CL_Core5_MHARTID;
+    assign CLUSTER_CORE_ID[6] = CL_Core6_MHARTID;
+    assign CLUSTER_CORE_ID[7] = CL_Core7_MHARTID;
+
+    
     localparam dm::hartinfo_t RI5CY_HARTINFO = '{
                                                 zero1:        '0,
                                                 nscratch:      2, // Debug module needs at least two scratch regs
@@ -821,12 +848,24 @@ module pulp_soc
         .tdo_oe_o             (                     )
     );
 
-    // assign hartinfo
-    always_comb begin
-        hartinfo = '{default: '0};
-        hartinfo[FC_Core_MHARTID] = RI5CY_HARTINFO;
-    end
-
+   // assign hartinfo
+   generate
+      for(nhart_var=0;nhart_var<NrHarts;nhart_var=nhart_var+1)
+        assign hartinfo[nhart_var] = '{
+                                       zero1:        '0,
+                                       nscratch:      2, // Debug module needs at least two scratch regs
+                                       zero0:        '0,
+                                       dataaccess: 1'b1, // data registers are memory mapped in the debugger
+                                       datasize: dm::DataCount,
+                                       dataaddr: dm::DataAddr
+                                       };
+   endgenerate
+   
+   generate
+      for(dbg_var=0;dbg_var<`NB_CORES;dbg_var=dbg_var+1)
+        assign cluster_dbg_irq_valid_o[dbg_var] = dm_debug_req[CLUSTER_CORE_ID[dbg_var]];
+   endgenerate
+   
     dm_top #(
        .NrHarts           ( NrHarts                   ),
        .BusWidth          ( 32                        ),

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -61,6 +61,7 @@ module pulp_soc
     input  logic [3:0]                    data_slave_aw_region_i,
     input  logic [7:0]                    data_slave_aw_len_i,
     input  logic [2:0]                    data_slave_aw_size_i,
+    //input  logic [5:0]                    data_slave_aw_atop_i,
     input  logic [1:0]                    data_slave_aw_burst_i,
     input  logic                          data_slave_aw_lock_i,
     input  logic [3:0]                    data_slave_aw_cache_i,
@@ -107,6 +108,7 @@ module pulp_soc
     output logic [3:0]                    data_master_aw_region_o,
     output logic [7:0]                    data_master_aw_len_o,
     output logic [2:0]                    data_master_aw_size_o,
+    // output logic [5:0]                    data_master_aw_atop_o,
     output logic [1:0]                    data_master_aw_burst_o,
     output logic                          data_master_aw_lock_o,
     output logic [3:0]                    data_master_aw_cache_o,
@@ -383,14 +385,16 @@ module pulp_soc
         .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH     ),
         .AXI_DATA_WIDTH ( AXI_DATA_OUT_WIDTH ),
         .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH   ),
-        .AXI_USER_WIDTH ( AXI_USER_WIDTH     )
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH     ),
+        .BUFFER_WIDTH   ( BUFFER_WIDTH      
     ) s_data_master ();
 
     AXI_BUS_ASYNC #(
         .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH    ),
         .AXI_DATA_WIDTH ( AXI_DATA_IN_WIDTH ),
         .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH  ),
-        .AXI_USER_WIDTH ( AXI_USER_WIDTH    )
+        .AXI_USER_WIDTH ( AXI_USER_WIDTH     ),
+        .BUFFER_WIDTH   ( BUFFER_WIDTH      
     ) s_data_slave ();
 
     AXI_BUS #(
@@ -400,12 +404,15 @@ module pulp_soc
         .AXI_USER_WIDTH ( AXI_USER_WIDTH    )
     ) s_data_in_bus ();
 
+
     AXI_BUS #(
         .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH    ),
         .AXI_DATA_WIDTH ( AXI_DATA_OUT_WIDTH),
         .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH  ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH    )
     ) s_data_out_bus ();
+
+    //assign s_data_out_bus.aw_atop = 6'b0;
 
     FLL_BUS #(
         .FLL_ADDR_WIDTH ( FLL_ADDR_WIDTH ),
@@ -492,7 +499,7 @@ module pulp_soc
     ) dc_fifo_datain_bus_i (
         .clk_i            ( s_soc_clk               ),
         .rst_ni           ( s_rstn_cluster_sync_soc ),
-        // .test_cgbypass_i  ( 1'b0                    ),
+        .test_cgbypass_i  ( 1'b0                    ),
         .isolate_i        ( s_cluster_isolate_dc    ),
         .axi_slave        ( s_data_out_bus          ),
         .axi_master_async ( s_data_master           )
@@ -1030,6 +1037,7 @@ module pulp_soc
     assign s_data_slave.aw_len         = data_slave_aw_len_i         ;
     assign s_data_slave.aw_size        = data_slave_aw_size_i        ;
     assign s_data_slave.aw_burst       = data_slave_aw_burst_i       ;
+     //assign s_data_slave.aw_atop        = data_slave_aw_atop_i        ;
     assign s_data_slave.aw_lock        = data_slave_aw_lock_i        ;
     assign s_data_slave.aw_cache       = data_slave_aw_cache_i       ;
     assign s_data_slave.aw_qos         = data_slave_aw_qos_i         ;
@@ -1082,6 +1090,7 @@ module pulp_soc
     assign data_master_aw_region_o      = s_data_master.aw_region     ;
     assign data_master_aw_len_o         = s_data_master.aw_len        ;
     assign data_master_aw_size_o        = s_data_master.aw_size       ;
+    //assign data_master_aw_atop_o        = s_data_master.aw_atop       ;
     assign data_master_aw_burst_o       = s_data_master.aw_burst      ;
     assign data_master_aw_lock_o        = s_data_master.aw_lock       ;
     assign data_master_aw_cache_o       = s_data_master.aw_cache      ;

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -252,14 +252,6 @@ module pulp_soc
    
     localparam FC_Core_CORE_ID       = 4'd0;
     localparam FC_Core_MHARTID       = {FC_Core_CLUSTER_ID,1'b0,FC_Core_CORE_ID};
-    localparam CL_Core0_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd0};
-    localparam CL_Core1_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd1};
-    localparam CL_Core2_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd2};
-    localparam CL_Core3_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd3};
-    localparam CL_Core4_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd4};
-    localparam CL_Core5_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd5};
-    localparam CL_Core6_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd6};
-    localparam CL_Core7_MHARTID      = {CL_Core_CLUSTER_ID,1'b0,4'd7};
 
     /*
         PULP RISC-V cores have not continguos MHARTID.
@@ -273,19 +265,28 @@ module pulp_soc
         will remove the other flip flops and related logic.
     */
 
+    localparam logic [NB_CORES-1:0][10:0] CL_CORE_MHARTID  = CORE_CL_ID_FX();
+    function logic [NB_CORES-1:0][10:0] CORE_CL_ID_FX();
+        for (int ii=0; ii< NB_CORES; ii++) begin
+            CORE_CL_ID_FX[ii] = {CL_Core_CLUSTER_ID, 1'b0, ii[3:0]};
+        end
+    endfunction
+
     localparam NrHarts                               = 1024;
-    localparam logic [NrHarts-1:0] SELECTABLE_HARTS  = (1 << FC_Core_MHARTID) | (1 << CL_Core0_MHARTID) | (1 << CL_Core1_MHARTID) | (1 << CL_Core2_MHARTID) | (1 << CL_Core3_MHARTID) | (1 << CL_Core4_MHARTID) | (1 << CL_Core5_MHARTID) | (1 << CL_Core6_MHARTID) | (1 << CL_Core7_MHARTID);
+    localparam logic [NrHarts-1:0] SELECTABLE_HARTS = SEL_HARTS_FX();
+    function logic [NrHarts-1:0] SEL_HARTS_FX();
+        SEL_HARTS_FX = (1 << FC_Core_MHARTID);
+        for (int ii=0; ii< NB_CORES; ii++) begin
+            SEL_HARTS_FX |= (1 << CL_CORE_MHARTID[ii]);
+        end
+    endfunction
 
     logic [NB_CORES-1:0][10:0]   CLUSTER_CORE_ID;
 
-    assign CLUSTER_CORE_ID[0] = CL_Core0_MHARTID;
-    assign CLUSTER_CORE_ID[1] = CL_Core1_MHARTID;
-    assign CLUSTER_CORE_ID[2] = CL_Core2_MHARTID;
-    assign CLUSTER_CORE_ID[3] = CL_Core3_MHARTID;
-    assign CLUSTER_CORE_ID[4] = CL_Core4_MHARTID;
-    assign CLUSTER_CORE_ID[5] = CL_Core5_MHARTID;
-    assign CLUSTER_CORE_ID[6] = CL_Core6_MHARTID;
-    assign CLUSTER_CORE_ID[7] = CL_Core7_MHARTID;
+    genvar x_i;
+    for (x_i = 0; x_i < NB_CORES; x_i++) begin
+        assign CLUSTER_CORE_ID[x_i] = {CL_Core_CLUSTER_ID, 1'b0, x_i[3:0]};
+    end
 
     
     localparam dm::hartinfo_t RI5CY_HARTINFO = '{


### PR DESCRIPTION
This branch considers some modifications needed to make PULP working properly.

- Modifications of icache-related interfaces in the pulp_interface.sv module. This is needed for the integration of the hierarchical cache on the cluster side;

- Bump RISCY to a working version. There is a regression in the core, which breaks pulp. This regression is related to the mechanism with which the cluster cores read event from event unit.

- Added debug signals for cluster cores as well as related mhartid;

- Eliminated axi_mem_if IP from the ips_list. This IP actually can not be used in between the AXI and the TCDM L1 cluster memory, as it is not meant for this and generates conflicts with axi2mem IP which instead is used. On this point we will need further discussions on how to move on on this, but for the time being I think that the solution proposed is the best one.  (with the goal to have a stable PULP as soon as possible)

- added some params to make AXI interfaces working well on the SoC side

- Temporarily::: Renamed AXI_BUS and AXI_BUS_ASYNC interfaces to AXI_BUS2 and AXI_BUS_ASYNC2. This is to not generate conflicts with the new AXI interfaces from axi IP. In my opinion you could consider to eliminate such interfaces from pulp_interface.sv module.

- added some signals to deal with AXI atomic operations. Need to be tested. For the time being they are commented.

- The ips_list is updated with the new IPS like in pulpissimo-next branch. If this could raise some problems with this pull request, please let me know.

Additional comment: this pulp_soc works fine in PULP, passing all the tests I launched --> hello,  matrixMul floating and integer, runtime tests, dma.

If you need further clarifications, please let me know.