### PR TITLE
Fix wrong ID WIDTH in soc/cluster AXI bus

### DIFF
--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -389,7 +389,7 @@ module pulp_soc
     AXI_BUS_ASYNC #(
         .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH    ),
         .AXI_DATA_WIDTH ( AXI_DATA_IN_WIDTH ),
-        .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH  ),
+        .AXI_ID_WIDTH   ( AXI_ID_IN_WIDTH   ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH     ),
         .BUFFER_WIDTH   ( BUFFER_WIDTH       )
     ) s_data_slave ();
@@ -397,7 +397,7 @@ module pulp_soc
     AXI_BUS #(
         .AXI_ADDR_WIDTH ( AXI_ADDR_WIDTH    ),
         .AXI_DATA_WIDTH ( AXI_DATA_IN_WIDTH ),
-        .AXI_ID_WIDTH   ( AXI_ID_OUT_WIDTH  ),
+        .AXI_ID_WIDTH   ( AXI_ID_IN_WIDTH   ),
         .AXI_USER_WIDTH ( AXI_USER_WIDTH    )
     ) s_data_in_bus ();
 


### PR DESCRIPTION
This prevents synthesis. Fixes #22