### PR TITLE
Adapt fabric controller subsystem for updated Ibex

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -70,7 +70,7 @@ riscv:
   commit: pulpissimo-v3.4.0
   domain: [cluster, soc]
 ibex:
-  commit: 13313952cd50ff04489f6cf3dba9ba05c2011a8b
+  commit: e65a27e14dda7bb3b09cadc4e9232305fd451cec
   group: lowRISC
   domain: [soc]
 scm:

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -62,9 +62,7 @@ module fc_subsystem #(
     logic [4:0]  core_irq_id    ;
     logic [4:0]  core_irq_ack_id;
     logic        core_irq_ack   ;
-    logic [14:0] core_irq_fast  ;
-
-    logic [3:0]  irq_ack_id;
+    logic [31:0] core_irq_x;
 
     // Boot address, core id, cluster id, fethc enable and core_status
     logic [31:0] boot_addr        ;
@@ -283,11 +281,12 @@ module fc_subsystem #(
         .irq_software_i        ( 1'b0              ),
         .irq_timer_i           ( 1'b0              ),
         .irq_external_i        ( 1'b0              ),
-        .irq_fast_i            ( core_irq_fast     ),
+        .irq_fast_i            ( 15'b0             ),
         .irq_nm_i              ( 1'b0              ),
 
-        .irq_ack_o             ( core_irq_ack      ),
-        .irq_ack_id_o          ( irq_ack_id        ),
+        .irq_x_i               ( core_irq_x        ),
+        .irq_x_ack_o           ( core_irq_ack      ),
+        .irq_x_ack_id_o        ( core_irq_ack_id   ),
 
         .debug_req_i           ( debug_req_i       ),
 
@@ -301,24 +300,12 @@ module fc_subsystem #(
 
     generate
     if ( USE_IBEX == 1) begin : convert_irqs
-    // Ibex supports 15 fast interrupts and reads the interrupt lines directly
+    // Ibex supports 32 additional fast interrupts and reads the interrupt lines directly.
     // Convert ID back to interrupt lines
-    always_comb begin : gen_core_irq_fast
-        core_irq_fast = '0;
-        if (core_irq_req && (core_irq_id == 26)) begin
-            // remap SoC Event FIFO
-            core_irq_fast[10] = 1'b1;
-        end else if (core_irq_req && (core_irq_id < 15)) begin
-            core_irq_fast[core_irq_id] = 1'b1;
-        end
-    end
-
-    // remap ack ID for SoC Event FIFO
-    always_comb begin : gen_core_irq_ack_id
-        if (irq_ack_id == 10) begin
-            core_irq_ack_id = 26;
-        end else begin
-            core_irq_ack_id = {1'b0, irq_ack_id};
+    always_comb begin : gen_core_irq_x
+        core_irq_x = '0;
+        if (core_irq_req) begin
+            core_irq_x[core_irq_id] = 1'b1;
         end
     end
 

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -243,13 +243,20 @@ module fc_subsystem #(
 `else
     ibex_core #(
 `endif
-        .PMPEnable           ( 0            ),
-        .MHPMCounterNum      ( 8            ),
-        .MHPMCounterWidth    ( 40           ),
-        .RV32E               ( IBEX_RV32E   ),
-        .RV32M               ( IBEX_RV32M   ),
-        .DmHaltAddr          ( 32'h1A110800 ),
-        .DmExceptionAddr     ( 32'h1A110808 )
+        .PMPEnable                ( 1'b0         ),
+        .MHPMCounterNum           ( 10           ),
+        .MHPMCounterWidth         ( 40           ),
+        .RV32E                    ( IBEX_RV32E   ),
+        .RV32M                    ( IBEX_RV32M   ),
+        .RV32B                    ( 1'b0         ),
+        .BranchTargetALU          ( 1'b0         ),
+        .WritebackStage           ( 1'b0         ),
+        .MultiplierImplementation ( "fast"       ),
+        .ICache                   ( 1'b0         ),
+        .DbgTriggerEn             ( 1'b1         ),
+        .SecureIbex               ( 1'b0         ),
+        .DmHaltAddr               ( 32'h1A110800 ),
+        .DmExceptionAddr          ( 32'h1A110808 )
     ) lFC_CORE (
         .clk_i                 ( clk_i             ),
         .rst_ni                ( rst_ni            ),

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -546,7 +546,6 @@ module pulp_soc
     //********************************************************
 
     soc_peripherals #(
-        .CORE_TYPE          ( CORE_TYPE                             ),
         .MEM_ADDR_WIDTH     ( L2_MEM_ADDR_WIDTH+$clog2(NB_L2_BANKS) ),
         .APB_ADDR_WIDTH     ( 32                                    ),
         .APB_DATA_WIDTH     ( 32                                    ),

--- a/rtl/pulp_soc/soc_peripherals.sv
+++ b/rtl/pulp_soc/soc_peripherals.sv
@@ -11,7 +11,6 @@
 `include "pulp_soc_defines.sv"
 
 module soc_peripherals #(
-    parameter CORE_TYPE      = 0,
     parameter MEM_ADDR_WIDTH = 13,
     parameter APB_ADDR_WIDTH = 32,
     parameter APB_DATA_WIDTH = 32,
@@ -146,8 +145,6 @@ module soc_peripherals #(
     output logic                       cluster_irq_o
 );
 
-    localparam USE_IBEX = CORE_TYPE == 1 || CORE_TYPE == 2;
-
     APB_BUS s_fll_bus ();
 
     APB_BUS s_gpio_bus ();
@@ -198,8 +195,6 @@ module soc_peripherals #(
     assign s_events[141]              = fc_hwpe_events_i[1];
     assign s_events[159:142]          = '0;
 
-    generate
-    if ( USE_IBEX == 0) begin: FC_EVENTS
     assign fc_events_o[7:0] = 8'h0; //RESERVED for sw events
     assign fc_events_o[8]   = dma_pe_evt_i;
     assign fc_events_o[9]   = dma_pe_irq_i;
@@ -229,25 +224,6 @@ module soc_peripherals #(
     assign fc_events_o[29]  = s_fc_err_events;
     assign fc_events_o[30]  = s_fc_hp_events[0];
     assign fc_events_o[31]  = s_fc_hp_events[1];
-    end else begin : FC_EVENTS
-    assign fc_events_o[0]     = s_timer_lo_event;
-    assign fc_events_o[1]     = s_timer_hi_event;
-    assign fc_events_o[2]     = s_ref_rise_event | s_ref_fall_event;
-    assign fc_events_o[3]     = s_gpio_event;
-    assign fc_events_o[4]     = s_adv_timer_events[0];
-    assign fc_events_o[5]     = s_adv_timer_events[1];
-    assign fc_events_o[6]     = s_adv_timer_events[2];
-    assign fc_events_o[7]     = s_adv_timer_events[3];
-    assign fc_events_o[8]     = 1'b0; // not used
-    assign fc_events_o[9]     = 1'b0; // not used
-    assign fc_events_o[10]    = 1'b0; //RESERVED for soc event FIFO
-    assign fc_events_o[11]    = s_fc_err_events;
-    assign fc_events_o[12]    = s_fc_hp_events[0];
-    assign fc_events_o[13]    = s_fc_hp_events[1];
-    assign fc_events_o[14]    = 1'b0; // not used
-    assign fc_events_o[31:15] = 17'b0; // not supported by Ibex
-    end
-    endgenerate
 
     pulp_sync_wedge i_ref_clk_sync (
         .clk_i    ( clk_i            ),


### PR DESCRIPTION
The PULPissimo-version of Ibex now supports 32 additional fast interrupts like RI5CY/CV32E40P. This allows the two cores to use the exact same interrupt framework.