### PR TITLE
Update ips_list.yml

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -92,7 +92,7 @@ udma/udma_i2c:
   commit: vega_v1.0.0
   domain: [soc]
 udma/udma_i2s:
-  commit: v1.0.0
+  commit: v1.1.0
   domain: [soc]
 udma/udma_qspi:
   commit: v1.0.0


### PR DESCRIPTION
The previous version of the i2s would cause issues leading to undriven gates. Updated to a more recent tag which fixes the problem.