### PR TITLE
Pulpissimo next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+### Changed
+### Removed
+### Fixed
+
+## [1.4.0] - 2020-10-02
+### Changed
+- Bump `fpnew` to `v0.6.3`
+
+### Fixed
+- Fix drive input address in bootrom
+
+## [1.3.0] - 2020-07-30
 ### Changed
 - Bump `udma_i2s` to `v1.1.0`
 

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -61,7 +61,7 @@ common_cells:
   commit: v1.13.1
   domain: [cluster, soc]
 fpnew:
-  commit: v0.6.1
+  commit: v0.6.3
   domain: [cluster, soc]
 jtag_pulp:
   commit: v0.1

--- a/rtl/pulp_soc/boot_rom.sv
+++ b/rtl/pulp_soc/boot_rom.sv
@@ -34,7 +34,7 @@ module boot_rom #(
             .Q              (  mem_slave.rdata      )
         );
 
-        assign mem_slave.add[31:ROM_ADDR_WIDTH] = '0;
+        // assign mem_slave.add[31:ROM_ADDR_WIDTH] = '0;
 
     `else // !`ifndef PULP_FPGA_EMUL
 


### PR DESCRIPTION
* fpnew: Bump to `v0.6.3` with divider flag fix and lint improvements
* boot_rom: Stop driving input address