### PR TITLE
Zfinx patch on latest SoC version

### DIFF
--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -22,7 +22,8 @@ module fc_subsystem #(
     parameter PULP_SECURE         = 1,
     parameter TB_RISCV            = 0,
     parameter CORE_ID             = 4'h0,
-    parameter CLUSTER_ID          = 6'h1F
+    parameter CLUSTER_ID          = 6'h1F,
+    parameter USE_Zfinx		  = 1
 )
 (
     input  logic                      clk_i,
@@ -127,7 +128,8 @@ module fc_subsystem #(
         .FPU                 ( USE_FPU             ),
         .FP_DIVSQRT          ( USE_FPU             ),
         .SHARED_FP           ( 0                   ),
-        .SHARED_FP_DIVSQRT   ( 2                   )
+        .SHARED_FP_DIVSQRT   ( 2                   ),
+	.Zfinx	     	     ( USE_Zfinx	   )
     ) lFC_CORE (
         .clk_i                 ( clk_i             ),
         .rst_ni                ( rst_ni            ),

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -23,7 +23,7 @@ module fc_subsystem #(
     parameter TB_RISCV            = 0,
     parameter CORE_ID             = 4'h0,
     parameter CLUSTER_ID          = 6'h1F,
-    parameter USE_ZFINX		  = 1
+    parameter USE_ZFINX           = 1
 )
 (
     input  logic                      clk_i,
@@ -129,7 +129,7 @@ module fc_subsystem #(
         .FP_DIVSQRT          ( USE_FPU             ),
         .SHARED_FP           ( 0                   ),
         .SHARED_FP_DIVSQRT   ( 2                   ),
-        .Zfinx	     	     ( USE_ZFINX	   )
+        .Zfinx               ( USE_ZFINX           )
     ) lFC_CORE (
         .clk_i                 ( clk_i             ),
         .rst_ni                ( rst_ni            ),

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -23,7 +23,7 @@ module fc_subsystem #(
     parameter TB_RISCV            = 0,
     parameter CORE_ID             = 4'h0,
     parameter CLUSTER_ID          = 6'h1F,
-    parameter USE_Zfinx		  = 1
+    parameter USE_ZFINX		  = 1
 )
 (
     input  logic                      clk_i,
@@ -129,7 +129,7 @@ module fc_subsystem #(
         .FP_DIVSQRT          ( USE_FPU             ),
         .SHARED_FP           ( 0                   ),
         .SHARED_FP_DIVSQRT   ( 2                   ),
-	.Zfinx	     	     ( USE_Zfinx	   )
+        .Zfinx	     	     ( USE_ZFINX	   )
     ) lFC_CORE (
         .clk_i                 ( clk_i             ),
         .rst_ni                ( rst_ni            ),

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -38,7 +38,9 @@ module pulp_soc import dm::*; #(
 
     parameter int unsigned N_UART = 1,
     parameter int unsigned N_SPI  = 1,
-    parameter int unsigned N_I2C  = 2
+    parameter int unsigned N_I2C  = 2,
+
+    parameter USE_Zfinx 	  = 1
 ) (
     input  logic                          ref_clk_i,
     input  logic                          slow_clk_i,
@@ -714,7 +716,8 @@ module pulp_soc import dm::*; #(
         .USE_FPU    ( USE_FPU            ),
         .CORE_ID    ( FC_CORE_CORE_ID    ),
         .CLUSTER_ID ( FC_CORE_CLUSTER_ID ),
-        .USE_HWPE   ( USE_HWPE           )
+        .USE_HWPE   ( USE_HWPE           ),
+	.USE_Zfinx  ( USE_Zfinx		 )
     ) fc_subsystem_i (
         .clk_i               ( s_soc_clk           ),
         .rst_ni              ( s_soc_rstn          ),

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -40,7 +40,7 @@ module pulp_soc import dm::*; #(
     parameter int unsigned N_SPI  = 1,
     parameter int unsigned N_I2C  = 2,
 
-    parameter USE_ZFINX 	  = 1
+    parameter USE_ZFINX           = 1
 ) (
     input  logic                          ref_clk_i,
     input  logic                          slow_clk_i,
@@ -717,7 +717,7 @@ module pulp_soc import dm::*; #(
         .CORE_ID    ( FC_CORE_CORE_ID    ),
         .CLUSTER_ID ( FC_CORE_CLUSTER_ID ),
         .USE_HWPE   ( USE_HWPE           ),
-        .USE_ZFINX  ( USE_ZFINX	         )
+        .USE_ZFINX  ( USE_ZFINX          )
     ) fc_subsystem_i (
         .clk_i               ( s_soc_clk           ),
         .rst_ni              ( s_soc_rstn          ),

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -40,7 +40,7 @@ module pulp_soc import dm::*; #(
     parameter int unsigned N_SPI  = 1,
     parameter int unsigned N_I2C  = 2,
 
-    parameter USE_Zfinx 	  = 1
+    parameter USE_ZFINX 	  = 1
 ) (
     input  logic                          ref_clk_i,
     input  logic                          slow_clk_i,
@@ -717,7 +717,7 @@ module pulp_soc import dm::*; #(
         .CORE_ID    ( FC_CORE_CORE_ID    ),
         .CLUSTER_ID ( FC_CORE_CLUSTER_ID ),
         .USE_HWPE   ( USE_HWPE           ),
-	.USE_Zfinx  ( USE_Zfinx		 )
+        .USE_ZFINX  ( USE_ZFINX	         )
     ) fc_subsystem_i (
         .clk_i               ( s_soc_clk           ),
         .rst_ni              ( s_soc_rstn          ),


### PR DESCRIPTION
Hi! :) 

Stemming from master, I had a patch on Zfinx for the FC core. Now is a parameter in input to the SoC and is put =1, in this way the floating point RF is neither instantiated nor used. Having Zfinx=0 causes all FP operations of executed by the FC to fail: the compiler works to support the Zfinx extension (Zfinx=1), hence it never loads any value in the fp register file but the FC doesn't know it (Zfinx=0) and fetches trash values from the FP reg file, causing FP op to fail. But I guess that no one had recently tired FP ops on the SoC. 

I tried it with the tests that you'll soon see in regression_tests and it works, along with the modifications Michael did on Pulp to bump to version 1.4.0. So, if you do not find errors, if could please merge this into master and tag as 1.4.2 that would be great.

Let me know in case there are any problems!!
Luca