### PR TITLE
Update axi infrastructure

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -45,9 +45,9 @@ apb_interrupt_cntrl:
 axi/axi:
   commit: v0.24.1
   domain: [cluster, soc]
-axi/axi_node:
-  commit: v1.1.4
-  domain: [cluster, soc]
+# axi/axi_node:
+#   commit: v1.1.4
+#   domain: [cluster, soc]
 axi/axi_slice:
   commit: v1.1.4
   domain: [cluster, soc]

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -43,7 +43,7 @@ apb_interrupt_cntrl:
   commit: v0.0.1
   domain: [soc]
 axi/axi:
-  commit: v0.7.1
+  commit: v0.24.1
   domain: [cluster, soc]
 axi/axi_node:
   commit: v1.1.4

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -61,7 +61,7 @@ common_cells:
   commit: v1.20.0
   domain: [cluster, soc]
 fpnew:
-  commit: v0.6.4
+  commit: v0.6.5
   domain: [cluster, soc]
 jtag_pulp:
   commit: v0.1

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -58,7 +58,7 @@ timer_unit:
   commit: v1.0.2
   domain: [cluster, soc]
 common_cells:
-  commit: v1.13.1
+  commit: v1.20.0
   domain: [cluster, soc]
 fpnew:
   commit: v0.6.4


### PR DESCRIPTION
Bump axi dependency to latest available working release
* This currently needs removal of `axi/axi_node` due to conflicting common_cells version requirements. `axi_node` should anways be replaced by `axi_xbar.sv`