### PR TITLE
Fixes #40

### DIFF
--- a/rtl/pulp_soc/l2_ram_multi_bank.sv
+++ b/rtl/pulp_soc/l2_ram_multi_bank.sv
@@ -51,24 +51,20 @@ module l2_ram_multi_bank #(
        assign interleaved_addresses[i] = mem_slave[i].add - `SOC_MEM_MAP_TCDM_START_ADDR;
 
       `ifndef PULP_FPGA_EMUL
-          /*
-           This model the hybrid SRAM and SCM configuration
-           that has been tape-out.
-           */
           generic_memory #(
-                           .ADDR_WIDTH ( INTL_MEM_ADDR_WIDTH ),
-                           .DATA_WIDTH ( 32                  )
-                           ) bank_i (
-                                               .CLK   ( clk_i                                             ),
-                                               .INITN ( 1'b1                                              ),
-                                               .CEN   ( ~mem_slave[i].req                                 ),
-                                               .BEN   ( ~mem_slave[i].be                                  ),
-                                               .WEN   ( mem_slave[i].wen                                  ),
-                                               .A     ( interleaved_addresses[i][INTL_MEM_ADDR_WIDTH+1:2] ), //Convert from
-                                                                                                             //byte to word addressing
-                                               .D     ( mem_slave[i].wdata                                ),
-                                               .Q     ( mem_slave[i].r_rdata                              )
-                                               );
+            .ADDR_WIDTH ( INTL_MEM_ADDR_WIDTH ),
+            .DATA_WIDTH ( 32                  )
+            ) bank_i (
+            .CLK   ( clk_i                                             ),
+            .INITN ( 1'b1                                              ),
+            .CEN   ( ~mem_slave[i].req                                 ),
+            .BEN   ( ~mem_slave[i].be                                  ),
+            .WEN   ( mem_slave[i].wen                                  ),
+            .A     ( interleaved_addresses[i][INTL_MEM_ADDR_WIDTH+2+$clog2(NB_BANKS)-1:2+$clog2(NB_BANKS)] ), // Remove LSBs for byte addressing (2 bits)
+                                                                                                              // and bank selection (log2(NB_BANKS) bits)
+            .D     ( mem_slave[i].wdata                                ),
+            .Q     ( mem_slave[i].r_rdata                              )
+            );
 
       `else // !`ifndef PULP_FPGA_EMUL
           fpga_interleaved_ram #(.ADDR_WIDTH(INTL_MEM_ADDR_WIDTH)) bank_i
@@ -78,7 +74,8 @@ module l2_ram_multi_bank #(
                .csn_i   (~mem_slave[i].req                                 ),
                .wen_i   (mem_slave[i].wen                                  ),
                .be_i    (mem_slave[i].be                                   ),
-               .addr_i  (interleaved_addresses[i][INTL_MEM_ADDR_WIDTH+1:2] ),
+               .addr_i  (interleaved_addresses[i][INTL_MEM_ADDR_WIDTH-1+2+$clog2(NB_BANKS):2+$clog2(NB_BANKS)] ), // Remove LSBs for byte addressing (2 bits)
+                                                                                                                  // and bank selection (log2(NB_BANKS) bits)
                .wdata_i (mem_slave[i].wdata                                ),
                .rdata_o (mem_slave[i].r_rdata                              )
                );


### PR DESCRIPTION
This commit fixes a serious bug in the way the address bits for the interleaved memory banks are extracted from the 32-bit TCDM addresses. For the interleaved memory space, we have to remove the 2 LSBs since the SRAMs are 32-bit word aligned while TCDM uses byte addressing. However, in addition to that, we also have to remove $clog2(Nr_banks) additional LSBs since those bits are used to select the memory bank in interleaved addressing. 