### PR TITLE
Bump dependencies with `tech_cells_generic` compatibility

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -46,7 +46,7 @@ dependencies:
   udma_external_per:      { git: "https://github.com/pulp-platform/udma_external_per.git", version: 1.0.3 }
   hwpe-mac-engine:        { git: "https://github.com/pulp-platform/hwpe-mac-engine.git", version: 1.3.3 }
   riscv-dbg:              { git: "https://github.com/pulp-platform/riscv-dbg.git", rev: "v0.2" }
-  register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: "b1bc9c22e0c2a5801107070c022904498dbae34b" }
+  register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: "2289fe025c27a39fd50f6578411e2f1af26fb442" }
   # apb for interface?
 
 sources:

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   L2_tcdm_hybrid_interco: { git: "https://github.com/pulp-platform/L2_tcdm_hybrid_interco.git", version: 1.0.0 }
   adv_dbg_if:             { git: "https://github.com/pulp-platform/adv_dbg_if.git", version: 0.0.2 }
   apb2per:                { git: "https://github.com/pulp-platform/apb2per.git", version: 0.1.0 }
-  apb_adv_timer:          { git: "https://github.com/pulp-platform/apb_adv_timer.git", version: 1.0.3 } # To be updated for tech_cells_generic versioning
+  apb_adv_timer:          { git: "https://github.com/pulp-platform/apb_adv_timer.git", version: 1.0.4 }
   apb_fll_if:             { git: "https://github.com/pulp-platform/apb_fll_if.git", version: 0.1.3 }
   apb_gpio:               { git: "https://github.com/pulp-platform/apb_gpio.git", rev: "0e9f142f2f11278445c953ad011fce1c7ed85b66" }
   apb_node:               { git: "https://github.com/pulp-platform/apb_node.git", version: 0.1.1 }
@@ -38,10 +38,10 @@ dependencies:
   udma_core:              { git: "https://github.com/pulp-platform/udma_core.git", version: 1.0.2 }
   udma_uart:              { git: "https://github.com/pulp-platform/udma_uart.git", version: 1.0.1 }
   udma_i2c:               { git: "https://github.com/pulp-platform/udma_i2c.git", version: 1.0.0 }
-  udma_i2s:               { git: "https://github.com/pulp-platform/udma_i2s.git", version: 1.1.1 } # To be updated for tech_cells_generic versioning
-  udma_qspi:              { git: "https://github.com/pulp-platform/udma_qspi.git", version: 1.0.3 } # To be updated for tech_cells_generic versioning
-  udma_sdio:              { git: "https://github.com/pulp-platform/udma_sdio.git", version: 1.1.0 } # To be updated for tech_cells_generic versioning
-  udma_camera:            { git: "https://github.com/pulp-platform/udma_camera.git", version: 1.1.1 } # To be updated for tech_cells_generic versioning
+  udma_i2s:               { git: "https://github.com/pulp-platform/udma_i2s.git", version: 1.1.2 }
+  udma_qspi:              { git: "https://github.com/pulp-platform/udma_qspi.git", version: 1.0.4 }
+  udma_sdio:              { git: "https://github.com/pulp-platform/udma_sdio.git", version: 1.1.2 }
+  udma_camera:            { git: "https://github.com/pulp-platform/udma_camera.git", version: 1.1.2 }
   udma_filter:            { git: "https://github.com/pulp-platform/udma_filter.git", version: 1.0.2 }
   udma_external_per:      { git: "https://github.com/pulp-platform/udma_external_per.git", version: 1.0.3 }
   hwpe-mac-engine:        { git: "https://github.com/pulp-platform/hwpe-mac-engine.git", version: 1.3.3 }

--- a/Bender.yml
+++ b/Bender.yml
@@ -45,7 +45,7 @@ dependencies:
   udma_filter:            { git: "https://github.com/pulp-platform/udma_filter.git", version: 1.0.2 }
   udma_external_per:      { git: "https://github.com/pulp-platform/udma_external_per.git", version: 1.0.3 }
   hwpe-mac-engine:        { git: "https://github.com/pulp-platform/hwpe-mac-engine.git", version: 1.3.3 }
-  riscv-dbg:              { git: "https://github.com/pulp-platform/riscv-dbg.git", rev: "v0.2" }
+  riscv-dbg:              { git: "https://github.com/pulp-platform/riscv-dbg.git", version: 0.2.0 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: 0.2.1 }
   # apb for interface?
 

--- a/Bender.yml
+++ b/Bender.yml
@@ -46,7 +46,7 @@ dependencies:
   udma_external_per:      { git: "https://github.com/pulp-platform/udma_external_per.git", version: 1.0.3 }
   hwpe-mac-engine:        { git: "https://github.com/pulp-platform/hwpe-mac-engine.git", version: 1.3.3 }
   riscv-dbg:              { git: "https://github.com/pulp-platform/riscv-dbg.git", rev: "v0.2" }
-  register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", rev: "2289fe025c27a39fd50f6578411e2f1af26fb442" }
+  register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: 0.2.1 }
   # apb for interface?
 
 sources:

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -118,5 +118,5 @@ riscv-dbg:
   commit: v0.2
   domain: [soc]
 register_interface:
-  commit: b1bc9c22e0c2a5801107070c022904498dbae34b
+  commit: 2289fe025c27a39fd50f6578411e2f1af26fb442
   domain: [soc]

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -118,5 +118,5 @@ riscv-dbg:
   commit: v0.2
   domain: [soc]
 register_interface:
-  commit: 2289fe025c27a39fd50f6578411e2f1af26fb442
+  commit: v0.2.1
   domain: [soc]

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -115,7 +115,7 @@ hwpe-mac-engine:
   commit: v1.3.3
   domain: [cluster, soc]
 riscv-dbg:
-  commit: v0.2
+  commit: v0.2.0
   domain: [soc]
 register_interface:
   commit: v0.2.1

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -33,7 +33,7 @@ apb/apb2per:
   commit: v0.1.0
   domain: [soc]
 apb/apb_adv_timer:
-  commit: v1.0.3
+  commit: v1.0.4
   domain: [soc]
 apb/apb_fll_if:
   commit: v0.1.3
@@ -94,16 +94,16 @@ udma/udma_i2c:
   commit: v1.0.0
   domain: [soc]
 udma/udma_i2s:
-  commit: v1.1.1
+  commit: v1.1.2
   domain: [soc]
 udma/udma_qspi:
-  commit: v1.0.3
+  commit: v1.0.4
   domain: [soc]
 udma/udma_sdio:
-  commit: v1.1.0
+  commit: v1.1.2
   domain: [soc]
 udma/udma_camera:
-  commit: v1.1.1
+  commit: v1.1.2
   domain: [soc]
 udma/udma_filter:
   commit: v1.0.2


### PR DESCRIPTION
This PR updates certain dependencies to reference newer versions of `tech_cells_generic`, such that no version conflicts persist across dependencies. This allows for bender to automatically resolve dependencies, without requiring an override or manual selection of a version, at least regarding `tech_cells_generic`.

This issue still persists for `axi` due to `axi_slice_dc` calling an older `axi` version. `register_interface` is updated here to avoid this issue.