### PR TITLE
Remove duplicate interface APB_BUS

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -14,6 +14,7 @@ package:
 
 dependencies:
   L2_tcdm_hybrid_interco: { git: "https://github.com/pulp-platform/L2_tcdm_hybrid_interco.git", version: 1.0.0 }
+  apb:                    { git: "https://github.com/pulp-platform/apb.git", version:  0.1.0 }
   adv_dbg_if:             { git: "https://github.com/pulp-platform/adv_dbg_if.git", version: 0.0.2 }
   apb2per:                { git: "https://github.com/pulp-platform/apb2per.git", version: 0.1.0 }
   apb_adv_timer:          { git: "https://github.com/pulp-platform/apb_adv_timer.git", version: 1.0.3 } # To be updated for tech_cells_generic versioning

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -29,6 +29,9 @@ cluster_interconnect:
 adv_dbg_if:
   commit: v0.0.2
   domain: [cluster, soc]
+apb/apb:
+  commit: v0.1.0
+  domain: [soc]
 apb/apb2per:
   commit: v0.1.0
   domain: [soc]

--- a/rtl/components/pulp_interfaces.sv
+++ b/rtl/components/pulp_interfaces.sv
@@ -1137,51 +1137,6 @@ interface L0_CTRL_UNIT_BUS;
 
 endinterface //~ L0_CTRL_UNIT_BUS
 
-//////////////////////////////////////////////////////////////
-//                                                          //
-//  █████╗ ██████╗ ██████╗     ██████╗ ██╗   ██╗███████╗    //
-// ██╔══██╗██╔══██╗██╔══██╗    ██╔══██╗██║   ██║██╔════╝    //
-// ███████║██████╔╝██████╔╝    ██████╔╝██║   ██║███████╗    //
-// ██╔══██║██╔═══╝ ██╔══██╗    ██╔══██╗██║   ██║╚════██║    //
-// ██║  ██║██║     ██████╔╝    ██████╔╝╚██████╔╝███████║    //
-// ╚═╝  ╚═╝╚═╝     ╚═════╝     ╚═════╝  ╚═════╝ ╚══════╝    //
-//                                                          //
-//////////////////////////////////////////////////////////////
-
-interface APB_BUS
-#(
-    parameter APB_ADDR_WIDTH = 32,
-    parameter APB_DATA_WIDTH = 32
-);
-
-    logic [APB_ADDR_WIDTH-1:0]                                        paddr;
-    logic [APB_DATA_WIDTH-1:0]                                        pwdata;
-    logic                                                             pwrite;
-    logic                                                             psel;
-    logic                                                             penable;
-    logic [APB_DATA_WIDTH-1:0]                                        prdata;
-    logic                                                             pready;
-    logic                                                             pslverr;
-
-
-   // Master Side
-   //***************************************
-   modport Master
-   (
-      output      paddr,  pwdata,  pwrite, psel,  penable,
-      input       prdata,          pready,        pslverr
-   );
-
-   // Slave Side
-   //***************************************
-   modport Slave
-   (
-      input      paddr,  pwdata,  pwrite, psel,  penable,
-      output     prdata,          pready,        pslverr
-   );
-
-endinterface
-
 //  ██████╗██╗   ██╗██████╗     ██████╗ ██╗   ██╗███████╗
 // ██╔════╝██║   ██║██╔══██╗    ██╔══██╗██║   ██║██╔════╝
 // ██║     ██║   ██║██████╔╝    ██████╔╝██║   ██║███████╗


### PR DESCRIPTION
This PR removes the definition of APB_BUS interface from the code base since it is already defined in the `apb` repository. This duplicate definition causes Spyglass to issue non-waivable fatal errors that prevent further linting of the design.