### PR TITLE
Align bender and ipapprox dependencies

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,7 @@ dependencies:
   apb_gpio:               { git: "https://github.com/pulp-platform/apb_gpio.git", rev: "0e9f142f2f11278445c953ad011fce1c7ed85b66" }
   apb_node:               { git: "https://github.com/pulp-platform/apb_node.git", version: 0.1.1 }
   apb_interrupt_cntrl:    { git: "https://github.com/pulp-platform/apb_interrupt_cntrl.git", version: 0.1.1 }
-  axi:                    { git: "https://github.com/pulp-platform/axi.git", version: 0.27.0 }
+  axi:                    { git: "https://github.com/pulp-platform/axi.git", version: 0.28.0 }
   # axi_node:               { git: "https://github.com/pulp-platform/axi_node.git", version: 1.1.4 } # deprecated, replaced by axi_xbar (in axi repo)
   axi_slice:              { git: "https://github.com/pulp-platform/axi_slice.git", version: 1.1.4 } # deprecated, replaced by axi_cut (in axi repo)
   axi_slice_dc:           { git: "https://github.com/pulp-platform/axi_slice_dc.git", version: 1.1.3 } # deprecated, replaced by axi_cdc (in axi repo)

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -51,7 +51,7 @@ apb_interrupt_cntrl:
   commit: v0.1.1
   domain: [soc]
 axi/axi:
-  commit: v0.27.0
+  commit: v0.28.0
   domain: [cluster, soc]
 # axi/axi_node:
 #   commit: v1.1.4
@@ -121,7 +121,7 @@ hwpe-mac-engine:
   commit: v1.3.3
   domain: [cluster, soc]
 riscv-dbg:
-  commit: v0.2.0
+  commit: v0.4.1
   domain: [soc]
 register_interface:
   commit: v0.2.1


### PR DESCRIPTION
IPApprox and Bender.yml dependency versions are out of sync. This commit fixes the issue.