### PR TITLE
Reduce Latency in AXI Crossbar of SoC interconnect and AXI-Lite to APB Bridge

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,7 @@ dependencies:
   apb_gpio:               { git: "https://github.com/pulp-platform/apb_gpio.git", rev: "0e9f142f2f11278445c953ad011fce1c7ed85b66" }
   apb_node:               { git: "https://github.com/pulp-platform/apb_node.git", version: 0.1.1 }
   apb_interrupt_cntrl:    { git: "https://github.com/pulp-platform/apb_interrupt_cntrl.git", version: 0.1.1 }
-  axi:                    { git: "https://github.com/pulp-platform/axi.git", version: 0.28.0 }
+  axi:                    { git: "https://github.com/pulp-platform/axi.git", version: 0.29.1 }
   # axi_node:               { git: "https://github.com/pulp-platform/axi_node.git", version: 1.1.4 } # deprecated, replaced by axi_xbar (in axi repo)
   axi_slice:              { git: "https://github.com/pulp-platform/axi_slice.git", version: 1.1.4 } # deprecated, replaced by axi_cut (in axi repo)
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: 1.0.2 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped riscv_dbg IP Version to 0.4.1
 - Switched to new AXI CDC IPs between SoC and Cluster
 - Switched to common cells CDC for cluster event exchange
+- Bumped axi IP Version to 0.29.1
+- Reduced latency of APB and AXI transactions
 ### Removed
 - Removed APB Bus interface from repository. The identical version defined in the APB depedency is now used 
 - Removed dependency to archived legacy axi_slice_dc

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -51,7 +51,7 @@ apb_interrupt_cntrl:
   commit: v0.1.1
   domain: [soc]
 axi/axi:
-  commit: v0.28.0
+  commit: v0.29.1
   domain: [cluster, soc]
 # axi/axi_node:
 #   commit: v1.1.4

--- a/rtl/pulp_soc/soc_interconnect.sv
+++ b/rtl/pulp_soc/soc_interconnect.sv
@@ -272,12 +272,13 @@ module soc_interconnect
                                                     MaxSlvTrans: 4,       //Allow up to 4 in-flight transactions
                                                     //per slave port
                                                     FallThrough: 1,       //Use the reccomended default config
-                                                    LatencyMode: axi_pkg::CUT_MST_PORTS,
+                                                    LatencyMode: axi_pkg::CUT_MST_AX | axi_pkg::MuxW,
                                                     AxiIdWidthSlvPorts: AXI_MASTER_ID_WIDTH,
                                                     AxiIdUsedSlvPorts: AXI_MASTER_ID_WIDTH,
                                                     AxiAddrWidth: BUS_ADDR_WIDTH,
                                                     AxiDataWidth: BUS_DATA_WIDTH,
-                                                    NoAddrRules: NR_ADDR_RULES_AXI_SLAVE_PORTS
+                                                    NoAddrRules: NR_ADDR_RULES_AXI_SLAVE_PORTS,
+                                                    UniqueIds: 0
                                                     };
 
     //Reverse interface array ordering since axi_xbar uses big-endian ordering of the arrays

--- a/rtl/pulp_soc/soc_interconnect_wrap.sv
+++ b/rtl/pulp_soc/soc_interconnect_wrap.sv
@@ -250,6 +250,8 @@ module soc_interconnect_wrap
                            .NoRules(1),
                            .AddrWidth(32),
                            .DataWidth(32),
+                           .PipelineRequest(1'b0),
+                           .PipelineResponse(1'b0),
                            .rule_t(addr_map_rule_t)
                            ) i_axi_lite_to_apb (
                                                 .clk_i,


### PR DESCRIPTION
This change reduces the pipeline stages in the AXI crossbar and axi-lite to APB peripheral. This reduces FC/uDMA to peripheral/cluster latency by 3 cycles.