### PR TITLE
Remove explicit fpga RAM instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed APB Bus interface from repository. The identical version defined in the APB depedency is now used 
 - Removed dependency to archived legacy axi_slice_dc
+- Removed ifdef for separate FPGA RAM instantiation. This is now supposed to be handled by tc_sram wrapping a Xilinx XPM.
 ### Fixed
 - Fixed Genus SystemVerilog incompatibility in soc_interconnect
 

--- a/rtl/pulp_soc/l2_ram_multi_bank.sv
+++ b/rtl/pulp_soc/l2_ram_multi_bank.sv
@@ -12,7 +12,6 @@
 
 module l2_ram_multi_bank #(
    parameter NB_BANKS                   = 4,
-   // Don't forget to adjust the SRAM macros and the FPGA settings if you change the banksizes
    parameter int unsigned BANK_SIZE_INTL_SRAM = 32768 //Number of 32-bit words
 ) (
    input logic             clk_i,
@@ -22,7 +21,6 @@ module l2_ram_multi_bank #(
    XBAR_TCDM_BUS.Slave     mem_slave[NB_BANKS],
    XBAR_TCDM_BUS.Slave     mem_pri_slave[2]
 );
-    // Don't forget to adjust the SRAM macros and the FPGA settings if you change the banksizes
     localparam int unsigned BANK_SIZE_PRI0       = 8192; //Number of 32-bit words
     localparam int unsigned BANK_SIZE_PRI1       = 8192; //Number of 32-bit words
 
@@ -51,37 +49,22 @@ module l2_ram_multi_bank #(
        //Remove Address offset
        assign interleaved_addresses[i] = mem_slave[i].add - `SOC_MEM_MAP_TCDM_START_ADDR;
 
-      `ifndef PULP_FPGA_EMUL
-          tc_sram #(
-            .NumWords  ( BANK_SIZE_INTL_SRAM ),
-            .DataWidth ( 32                  ),
-            .NumPorts  ( 1                   )
-          ) bank_i (
-            .clk_i,
-            .rst_ni,
-            .req_i   (  mem_slave[i].req                                  ),
-            .we_i    ( ~mem_slave[i].wen                                  ),
-            .addr_i  (  interleaved_addresses[i][INTL_MEM_ADDR_WIDTH+2+$clog2(NB_BANKS)-1:2+$clog2(NB_BANKS)] ), // Remove LSBs for byte addressing (2 bits)
-                                                                                                                 // and bank selection (log2(NB_BANKS) bits)
-            .wdata_i (  mem_slave[i].wdata                                ),
-            .be_i    (  mem_slave[i].be                                   ),
-            .rdata_o (  mem_slave[i].r_rdata                              )
-          );
+       tc_sram #(
+         .NumWords  ( BANK_SIZE_INTL_SRAM ),
+         .DataWidth ( 32                  ),
+         .NumPorts  ( 1                   )
+       ) bank_i (
+         .clk_i,
+         .rst_ni,
+         .req_i   (  mem_slave[i].req                                  ),
+         .we_i    ( ~mem_slave[i].wen                                  ),
+         .addr_i  (  interleaved_addresses[i][INTL_MEM_ADDR_WIDTH+2+$clog2(NB_BANKS)-1:2+$clog2(NB_BANKS)] ), // Remove LSBs for byte addressing (2 bits)
+                                                                                                              // and bank selection (log2(NB_BANKS) bits)
+         .wdata_i (  mem_slave[i].wdata                                ),
+         .be_i    (  mem_slave[i].be                                   ),
+         .rdata_o (  mem_slave[i].r_rdata                              )
+       );
 
-      `else // !`ifndef PULP_FPGA_EMUL
-          fpga_interleaved_ram #(.ADDR_WIDTH(INTL_MEM_ADDR_WIDTH)) bank_i
-              (
-               .clk_i,
-               .rst_ni,
-               .csn_i   (~mem_slave[i].req                                 ),
-               .wen_i   (mem_slave[i].wen                                  ),
-               .be_i    (mem_slave[i].be                                   ),
-               .addr_i  (interleaved_addresses[i][INTL_MEM_ADDR_WIDTH-1+2+$clog2(NB_BANKS):2+$clog2(NB_BANKS)] ), // Remove LSBs for byte addressing (2 bits)
-                                                                                                                  // and bank selection (log2(NB_BANKS) bits)
-               .wdata_i (mem_slave[i].wdata                                ),
-               .rdata_o (mem_slave[i].r_rdata                              )
-               );
-      `endif
    end
 
     // PRIVATE BANK0
@@ -98,7 +81,7 @@ module l2_ram_multi_bank #(
     //Remove Address offset
     logic [31:0] pri0_address;
     assign pri0_address = mem_pri_slave[0].add - `SOC_MEM_MAP_PRIVATE_BANK0_START_ADDR;
-   `ifndef PULP_FPGA_EMUL
+
     tc_sram #(
       .NumWords  ( BANK_SIZE_PRI0 ),
       .DataWidth ( 32             ),
@@ -114,21 +97,6 @@ module l2_ram_multi_bank #(
       .be_i    (  mem_pri_slave[0].be                   ),
       .rdata_o (  mem_pri_slave[0].r_rdata              )
     );
-   `else // !`ifndef PULP_FPGA_EMUL
-    fpga_private_ram #(
-      .ADDR_WIDTH(PRI0_MEM_ADDR_WIDTH)
-    ) bank_sram_pri0_i (
-      .clk_i,
-      .rst_ni,
-      .csn_i   ( ~mem_pri_slave[0].req                 ),
-      .wen_i   ( mem_pri_slave[0].wen                  ),
-      .be_i    ( mem_pri_slave[0].be                   ),
-      .addr_i  ( pri0_address[PRI0_MEM_ADDR_WIDTH+1:2] ), //Convert from byte to word addressing
-      .wdata_i ( mem_pri_slave[0].wdata                ),
-      .rdata_o ( mem_pri_slave[0].r_rdata              )
-    );
-   `endif // !`ifndef PULP_FPGA_EMUL
-
 
     // PRIVATE BANK1
     //Perform TCDM handshaking for constant 1 cycle latency
@@ -144,7 +112,7 @@ module l2_ram_multi_bank #(
     //Remove Address offset
     logic [31:0] pri1_address;
     assign pri1_address = mem_pri_slave[1].add - `SOC_MEM_MAP_PRIVATE_BANK1_START_ADDR;
-   `ifndef PULP_FPGA_EMUL
+
     tc_sram #(
       .NumWords  ( BANK_SIZE_PRI1 ),
       .DataWidth ( 32             ),
@@ -159,21 +127,7 @@ module l2_ram_multi_bank #(
       .wdata_i (  mem_pri_slave[1].wdata                ),
       .be_i    (  mem_pri_slave[1].be                   ),
       .rdata_o (  mem_pri_slave[1].r_rdata              )
-    );  
-   `else // !`ifndef PULP_FPGA_EMUL
-    fpga_private_ram #(
-      .ADDR_WIDTH(PRI1_MEM_ADDR_WIDTH)
-    ) bank_sram_pri1_i (
-      .clk_i,
-      .rst_ni,
-      .csn_i   ( ~mem_pri_slave[1].req                 ),
-      .wen_i   ( mem_pri_slave[1].wen                  ),
-      .be_i    ( mem_pri_slave[1].be                   ),
-      .addr_i  ( pri1_address[PRI1_MEM_ADDR_WIDTH+1:2] ), //Convert from byte to word addressing
-      .wdata_i ( mem_pri_slave[1].wdata                ),
-      .rdata_o ( mem_pri_slave[1].r_rdata              )
     );
-   `endif
 
 
 endmodule // l2_ram_multi_bank


### PR DESCRIPTION
The fpga ports no longer need out-context synthesis of the Xilinx SRAM IPs.
Instead the tech_cells_generic tc_sram wrapper will instantiate a xilinx
parametrized macro (if bender/IPapprox is given the right target). This way, we
no longer need to manually sync SRAM memory size between RTL and FPGA tcl scripts.