### PR TITLE
Align i2c with ack/busy/alert improvements

### DIFF
--- a/rtl/udma_subsystem/udma_subsystem.sv
+++ b/rtl/udma_subsystem/udma_subsystem.sv
@@ -18,7 +18,9 @@ module udma_subsystem
     parameter N_SPI          = 4,
     parameter N_UART         = 4,
     parameter N_I2C          = 1,
-    parameter N_HYPER        = 1 
+    parameter N_HYPER        = 1,
+
+    localparam N_PERIPH_MAX  = 32
 )
 (
     output logic                       L2_ro_wen_o    ,
@@ -56,7 +58,7 @@ module udma_subsystem
     output logic                       udma_apb_pready,
     output logic                       udma_apb_pslverr,
 
-    output logic            [32*4-1:0] events_o,
+    output logic            [N_PERIPH_MAX*4-1:0] events_o,
 
     input  logic                      event_valid_i,
     input  logic                [7:0] event_data_i,
@@ -95,7 +97,7 @@ module udma_subsystem
     output logic                 [3:0] sdio_data_o,
     input  logic                 [3:0] sdio_data_i,
     output logic                 [3:0] sdio_data_oen_o,
-    
+
     // I2S
     input  logic                       i2s_slave_sd0_i,
     input  logic                       i2s_slave_sd1_i,
@@ -133,9 +135,9 @@ module udma_subsystem
     localparam N_FILTER   = 1;
     localparam N_CH_HYPER = 8;
     localparam N_FPGA     = 0;
-`ifdef PULP_TRAINING	  
+`ifdef PULP_TRAINING
     localparam N_EXT_PER  = 1;
-`else			  
+`else
     localparam N_EXT_PER  = 0;
 `endif
 
@@ -149,6 +151,11 @@ module udma_subsystem
 
     localparam N_PERIPHS = N_SPI + N_HYPER + N_UART + N_MRAM + N_I2C + N_CAM + N_I2S + N_CSI2 + N_SDIO + N_JTAG + N_FILTER + N_FPGA + N_EXT_PER + N_CH_HYPER;
 
+    // Currently s_events is designed for N_PERIPH=32. If we change this then
+    // make sure all the events are correctly mapped and connected.
+    if (N_PERIPHS > N_PERIPH_MAX)
+        $fatal(1, "number of events is desigend for at most %d peripherals", N_PERIPH_MAX);
+
     // TX Channels
     localparam CH_ID_TX_UART    = 0;
     localparam CH_ID_TX_SPIM    = N_UART;
@@ -161,7 +168,7 @@ module udma_subsystem
     localparam CH_ID_TX_HYPER   = CH_ID_TX_CAM   + N_CAM  ;
     // Tx Ext Channel
     localparam CH_ID_TX_EXT_PER = CH_ID_TX_HYPER + N_HYPER + N_CH_HYPER;
- 
+
 
     // RX Channels
     localparam CH_ID_RX_UART    = 0;
@@ -180,18 +187,18 @@ module udma_subsystem
     localparam CH_ID_EXT_TX_FILTER = 0;
     localparam CH_ID_EXT_RX_FILTER = 0;
 
-    localparam PER_ID_UART    = 0;                  
-    localparam PER_ID_SPIM    = PER_ID_UART   + N_UART   ;     
-    localparam PER_ID_I2C     = PER_ID_SPIM   + N_SPI    ;     
-    localparam PER_ID_SDIO    = PER_ID_I2C    + N_I2C    ; 
-    localparam PER_ID_I2S     = PER_ID_SDIO   + N_SDIO   ; 
-    localparam PER_ID_CAM     = PER_ID_I2S    + N_I2S    ; 
-    localparam PER_ID_FILTER  = PER_ID_CAM    + N_CAM    ; 
+    localparam PER_ID_UART    = 0;
+    localparam PER_ID_SPIM    = PER_ID_UART   + N_UART   ;
+    localparam PER_ID_I2C     = PER_ID_SPIM   + N_SPI    ;
+    localparam PER_ID_SDIO    = PER_ID_I2C    + N_I2C    ;
+    localparam PER_ID_I2S     = PER_ID_SDIO   + N_SDIO   ;
+    localparam PER_ID_CAM     = PER_ID_I2S    + N_I2S    ;
+    localparam PER_ID_FILTER  = PER_ID_CAM    + N_CAM    ;
     localparam PER_ID_HYPER   = PER_ID_FILTER + N_FILTER ;
     localparam PER_ID_EXT_PER = PER_ID_HYPER  + N_HYPER  + N_CH_HYPER;
 
 
-    
+
 
     logic [N_TX_CHANNELS-1:0] [L2_AWIDTH_NOAL-1 : 0] s_tx_cfg_startaddr;
     logic [N_TX_CHANNELS-1:0]     [TRANS_SIZE-1 : 0] s_tx_cfg_size;
@@ -258,7 +265,7 @@ module udma_subsystem
     logic [N_STREAMS-1:0]                             s_stream_eot;
     logic [N_STREAMS-1:0]                             s_stream_ready;
 
-    logic [16*8-1:0] s_events;
+    logic [N_PERIPH_MAX*4-1:0] s_events;
 
     logic         [1:0] s_rf_event;
 
@@ -273,15 +280,15 @@ module udma_subsystem
     logic [N_PERIPHS-1:0]        s_periph_ready;
 
     logic            [N_SPI-1:0] s_spi_eot;
-    logic            [N_I2C-1:0] s_i2c_evt;
+    logic            [N_I2C-1:0] s_i2c_err;
     logic            [N_I2C-1:0] s_i2c_eot;
+    logic            [N_I2C-1:0] s_i2c_nack;
     logic           [N_UART-1:0] s_uart_evt;
 
     logic         [3:0] s_trigger_events;
 
     logic s_cam_evt;
     logic s_i2s_evt;
-    logic s_i2c1_evt;
 
     logic s_filter_eot_evt;
     logic s_filter_act_evt;
@@ -609,7 +616,11 @@ module udma_subsystem
             assign s_events[4*(PER_ID_I2C+g_i2c)+0] = s_rx_ch_events[CH_ID_RX_I2C+g_i2c];
             assign s_events[4*(PER_ID_I2C+g_i2c)+1] = s_tx_ch_events[CH_ID_TX_I2C+g_i2c];
             assign s_events[4*(PER_ID_I2C+g_i2c)+2] = s_tx_ch_events[CH_ID_CMD_I2C+g_i2c];
-            assign s_events[4*(PER_ID_I2C+g_i2c)+3] = s_i2c_eot[g_i2c];
+            assign s_events[4*(PER_ID_I2C+g_i2c)+3] = s_i2c_eot[g_i2c]; // end of transfer event
+
+            // Since the number of events is > 4, we map them to the end of the s_events array to not break the existing schema
+            assign s_events[(4*N_PERIPH_MAX-2*N_I2C+g_i2c)+0] = s_i2c_nack[g_i2c]; // i2c slave device does not acknowledge the event
+            assign s_events[(4*N_PERIPH_MAX-N_I2C+g_i2c)+0] = s_i2c_err[g_i2c]; // errors
 
             assign s_rx_cfg_stream[CH_ID_RX_I2C+g_i2c] = 'h0;
             assign s_rx_cfg_stream_id[CH_ID_RX_I2C+g_i2c] = 'h0;
@@ -627,7 +638,6 @@ module udma_subsystem
                 .sys_clk_i           ( s_clk_periphs_core[PER_ID_I2C+g_i2c]      ),
                 .periph_clk_i        ( s_clk_periphs_per[PER_ID_I2C+g_i2c]       ),
                 .rstn_i              ( sys_resetn_i                              ),
-
                 .cfg_data_i          ( s_periph_data_to                          ),
                 .cfg_addr_i          ( s_periph_addr                             ),
                 .cfg_valid_i         ( s_periph_valid[PER_ID_I2C+g_i2c]          ),
@@ -684,9 +694,9 @@ module udma_subsystem
                 .data_rx_valid_o     ( s_rx_ch_valid[CH_ID_RX_I2C+g_i2c]         ),
                 .data_rx_ready_i     ( s_rx_ch_ready[CH_ID_RX_I2C+g_i2c]         ),
 
-                .err_o               ( s_i2c_evt[g_i2c]                          ),
+                .err_o               ( s_i2c_err[g_i2c]                          ),
                 .eot_o               ( s_i2c_eot[g_i2c]                          ),
-                .nack_o              (),
+                .nack_o              ( s_i2c_nack[g_i2c]                         ),
 
                 .scl_i               ( i2c_scl_i[g_i2c]                          ),
                 .scl_o               ( i2c_scl_o[g_i2c]                          ),
@@ -978,18 +988,18 @@ module udma_subsystem
     assign s_events[4*PER_ID_HYPER+3]          = |s_evt_eot_hyper & !is_hyper_read_d;
 
     always_ff @(posedge s_clk_periphs_core[PER_ID_HYPER], negedge sys_resetn_i) begin
-       if(!sys_resetn_i) 
+       if(!sys_resetn_i)
              is_hyper_read_q <= 1'b0;
        else
              is_hyper_read_q <= is_hyper_read_d;
-    end 
+    end
     always_comb begin
            if(is_hyper_read_q) begin
                 if ( s_tx_ch_events[CH_ID_TX_HYPER] & !s_rx_ch_events[CH_ID_RX_HYPER]) begin
                       is_hyper_read_d = 1'b0;
                 end
                 else  is_hyper_read_d = 1'b1;
-           end 
+           end
            else if(!is_hyper_read_q) begin
                 if ( s_rx_ch_events[CH_ID_RX_HYPER] & !s_tx_ch_events[CH_ID_TX_HYPER]) begin
                       is_hyper_read_d = 1'b1;


### PR DESCRIPTION
## Overview

Align `udma_subsystem` with the improved capability of an i2c master device to receive an error (`nack`) from an i2c slave device after a write:

- `nack` register is held high until further read and does not last for a clock cycle only
- `busy`, `alert` and `error` logic is wired in `udma_i2c` (it was unconnected)
- `busy` and `alert` receive the same priority of `nack`, i.e. they are kept at `1` until the nack is recognized, and an error is raised

## Regression check

- This branch has been tested with the pulp-runtime based [i2c master regression test](https://github.com/pulp-platform/regression_tests/tree/master/peripherals/i2c) in `pulp-open` `master` branch. Yet, the test still does not check for `nack` from a slave device; it has been executed to check against regression at the moment.
- The `ack` check needs to be added in the sw drivers and properly tested