### PR TITLE
Update RI5CY to CV32E40P

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -30,7 +30,7 @@ dependencies:
   cluster_interconnect:   { git: "https://github.com/pulp-platform/cluster_interconnect.git", version: 1.1.1 }
   fpnew:                  { git: "https://github.com/pulp-platform/fpnew.git", version: 0.6.6 }
   jtag_pulp:              { git: "https://github.com/pulp-platform/jtag_pulp.git", rev: "v0.1" }
-  cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "pulpissimo-v3.4.0-rev4"}
+  cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "pulpissimo-v4.0.0"}
   ibex:                   { git: "https://github.com/pulp-platform/ibex.git", rev: "pulpissimo-v6.1.2" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: 1.0.1}
   generic_FLL:            { git: "https://github.com/pulp-platform/generic_FLL.git", rev: "1c92dc73a940392182fd4cb7b86f35649b349595" }

--- a/Bender.yml
+++ b/Bender.yml
@@ -84,11 +84,13 @@ sources:
       - rtl/fc/fc_demux.sv
       - rtl/fc/fc_subsystem.sv
       - rtl/fc/fc_hwpe.sv
+      - rtl/fc/cv32e40p_fp_wrapper.sv
   - target: not(rtl)
     files:
       - rtl/fc/fc_demux.sv
       - rtl/fc/fc_subsystem.sv
       - rtl/fc/fc_hwpe.sv
+      - rtl/fc/cv32e40p_fp_wrapper.sv
   # components
   - files:
       - rtl/components/apb_clkdiv.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update RI5CY to CV32E40P
+- Remove PULP_TRAINING references
+### Fixed
+- Wire up uart char and error events
 ## [3.3.0] - 2022-04-04
 ## Changed
 - Update riscv-dbg to v0.5.0 (synchronous jtag reset and bus error signaling)

--- a/rtl/fc/cv32e40p_fp_wrapper.sv
+++ b/rtl/fc/cv32e40p_fp_wrapper.sv
@@ -1,0 +1,116 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Wrapper for a fpnew
+// Contributor: Davide Schiavone <davide@openhwgroup.org>
+
+module cv32e40p_fp_wrapper import cv32e40p_apu_core_pkg::*; #(
+   parameter FP_DIVSQRT = 0
+)
+(
+   // Clock and Reset
+   input  logic                                   clk_i,
+   input  logic                                   rst_ni,
+
+   // APU Side: Master port
+   input  logic                                   apu_req_i,
+   output logic                                   apu_gnt_o,
+
+   // request channel
+   input  logic [APU_NARGS_CPU-1:0][31:0]         apu_operands_i,
+   input  logic [APU_WOP_CPU-1:0]                 apu_op_i,
+   input  logic [APU_NDSFLAGS_CPU-1:0]            apu_flags_i,
+
+   // response channel
+   output logic                                   apu_rvalid_o,
+   output logic [31:0]                            apu_rdata_o,
+   output logic [APU_NUSFLAGS_CPU-1:0]            apu_rflags_o
+);
+
+
+import cv32e40p_pkg::*;
+import fpnew_pkg::*;
+
+logic [fpnew_pkg::OP_BITS-1:0] fpu_op;
+logic                          fpu_op_mod;
+logic                          fpu_vec_op;
+
+logic [fpnew_pkg::FP_FORMAT_BITS-1:0]  fpu_dst_fmt;
+logic [fpnew_pkg::FP_FORMAT_BITS-1:0]  fpu_src_fmt;
+logic [fpnew_pkg::INT_FORMAT_BITS-1:0] fpu_int_fmt;
+logic [C_RM-1:0]             fp_rnd_mode;
+
+
+
+// assign apu_rID_o = '0;
+assign {fpu_vec_op, fpu_op_mod, fpu_op}                     = apu_op_i;
+
+assign {fpu_int_fmt, fpu_src_fmt, fpu_dst_fmt, fp_rnd_mode} = apu_flags_i;
+
+localparam C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
+
+// -----------
+// FPU Config
+// -----------
+// Features (enabled formats, vectors etc.)
+localparam fpnew_pkg::fpu_features_t FPU_FEATURES = '{
+  Width:         C_FLEN,
+  EnableVectors: C_XFVEC,
+  EnableNanBox:  1'b0,
+  FpFmtMask:     {C_RVF, C_RVD, C_XF16, C_XF8, C_XF16ALT},
+  IntFmtMask:    {C_XFVEC && C_XF8, C_XFVEC && (C_XF16 || C_XF16ALT), 1'b1, 1'b0}
+};
+
+// Implementation (number of registers etc)
+localparam fpnew_pkg::fpu_implementation_t FPU_IMPLEMENTATION = '{
+  PipeRegs:  '{// FP32, FP64, FP16, FP8, FP16alt
+               '{C_LAT_FP32, C_LAT_FP64, C_LAT_FP16, C_LAT_FP8, C_LAT_FP16ALT}, // ADDMUL
+               '{default: C_LAT_DIVSQRT}, // DIVSQRT
+               '{default: C_LAT_NONCOMP}, // NONCOMP
+               '{default: C_LAT_CONV}},   // CONV
+  UnitTypes: '{'{default: fpnew_pkg::MERGED},   // ADDMUL
+               '{default: C_DIV},   // DIVSQRT
+               '{default: fpnew_pkg::PARALLEL}, // NONCOMP
+               '{default: fpnew_pkg::MERGED}},  // CONV
+  PipeConfig: fpnew_pkg::AFTER
+};
+
+//---------------
+// FPU instance
+//---------------
+
+fpnew_top #(
+  .Features       ( FPU_FEATURES       ),
+  .Implementation ( FPU_IMPLEMENTATION ),
+  .TagType        ( logic              )
+) i_fpnew_bulk (
+  .clk_i          ( clk_i                                 ),
+  .rst_ni         ( rst_ni                                ),
+  .operands_i     ( apu_operands_i                        ),
+  .rnd_mode_i     ( fpnew_pkg::roundmode_e'(fp_rnd_mode)  ),
+  .op_i           ( fpnew_pkg::operation_e'(fpu_op)       ),
+  .op_mod_i       ( fpu_op_mod                            ),
+  .src_fmt_i      ( fpnew_pkg::fp_format_e'(fpu_src_fmt)  ),
+  .dst_fmt_i      ( fpnew_pkg::fp_format_e'(fpu_dst_fmt)  ),
+  .int_fmt_i      ( fpnew_pkg::int_format_e'(fpu_int_fmt) ),
+  .vectorial_op_i ( fpu_vec_op                            ),
+  .tag_i          ( 1'b0                                  ),
+  .in_valid_i     ( apu_req_i                             ),
+  .in_ready_o     ( apu_gnt_o                             ),
+  .flush_i        ( 1'b0                                  ),
+  .result_o       ( apu_rdata_o                           ),
+  .status_o       ( apu_rflags_o                          ),
+  .tag_o          ( /* unused */                          ),
+  .out_valid_o    ( apu_rvalid_o                          ),
+  .out_ready_i    ( 1'b1                                  ),
+  .busy_o         ( /* unused */                          )
+);
+
+endmodule // cv32e40p_fp_wrapper

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -15,6 +15,7 @@
 
 module pulp_soc import dm::*; #(
     parameter CORE_TYPE           = 0,
+    parameter USE_XPULP           = 1,
     parameter USE_FPU             = 1,
     parameter USE_HWPE            = 1,
     parameter USE_CLUSTER_EVENT   = 1,
@@ -761,11 +762,12 @@ module pulp_soc import dm::*; #(
 
     fc_subsystem #(
         .CORE_TYPE  ( CORE_TYPE          ),
+        .USE_XPULP  ( USE_XPULP          ),
         .USE_FPU    ( USE_FPU            ),
+        .USE_ZFINX  ( USE_ZFINX          ),
         .CORE_ID    ( FC_CORE_CORE_ID    ),
         .CLUSTER_ID ( FC_CORE_CLUSTER_ID ),
-        .USE_HWPE   ( USE_HWPE           ),
-        .USE_ZFINX  ( USE_ZFINX          )
+        .USE_HWPE   ( USE_HWPE           )
     ) fc_subsystem_i (
         .clk_i               ( s_soc_clk           ),
         .rst_ni              ( s_soc_rstn          ),

--- a/rtl/pulp_soc/soc_peripherals.sv
+++ b/rtl/pulp_soc/soc_peripherals.sv
@@ -684,22 +684,4 @@ module soc_peripherals #(
         .busy_o     (                         )
     );
 
-`ifdef PULP_TRAINING
-`ifndef SYNTHESIS
-
-    apb_dummy_registers  #(.APB_ADDR_WIDTH(APB_ADDR_WIDTH)) i_apb_dummy_reg_unit (
-        .HCLK       ( clk_i                   ),
-        .HRESETn    ( rst_ni                  ),
-        .PADDR      ( s_apb_dummy_bus.paddr   ),
-        .PWDATA     ( s_apb_dummy_bus.pwdata  ),
-        .PWRITE     ( s_apb_dummy_bus.pwrite  ),
-        .PSEL       ( s_apb_dummy_bus.psel    ),
-        .PENABLE    ( s_apb_dummy_bus.penable ),
-        .PRDATA     ( s_apb_dummy_bus.prdata  ),
-        .PREADY     ( s_apb_dummy_bus.pready  ),
-        .PSLVERR    ( s_apb_dummy_bus.pslverr )
-    );
-
-`endif
-`endif
 endmodule

--- a/rtl/udma_subsystem/udma_subsystem.sv
+++ b/rtl/udma_subsystem/udma_subsystem.sv
@@ -279,7 +279,9 @@ module udma_subsystem
     logic            [N_I2C-1:0] s_i2c_err;
     logic            [N_I2C-1:0] s_i2c_eot;
     logic            [N_I2C-1:0] s_i2c_nack;
-    logic           [N_UART-1:0] s_uart_evt;
+    logic           [N_UART-1:0] s_uart_char;
+    logic           [N_UART-1:0] s_uart_err;
+
 
     logic         [3:0] s_trigger_events;
 
@@ -300,7 +302,6 @@ module udma_subsystem
 
     assign s_cam_evt     = 1'b0;
     assign s_i2s_evt     = 1'b0;
-    assign s_uart_evt    = 1'b0;
 
     assign events_o      = s_events;
 
@@ -439,8 +440,8 @@ module udma_subsystem
         begin : i_uart_gen
             assign s_events[4*(PER_ID_UART+g_uart)+0] = s_rx_ch_events[CH_ID_RX_UART+g_uart];
             assign s_events[4*(PER_ID_UART+g_uart)+1] = s_tx_ch_events[CH_ID_TX_UART+g_uart];
-            assign s_events[4*(PER_ID_UART+g_uart)+2] = 1'b0;
-            assign s_events[4*(PER_ID_UART+g_uart)+3] = 1'b0;
+            assign s_events[4*(PER_ID_UART+g_uart)+2] = s_uart_char[g_uart];;
+            assign s_events[4*(PER_ID_UART+g_uart)+3] = s_uart_err[g_uart];
 
             assign s_rx_cfg_stream[CH_ID_RX_UART+g_uart] = 'h0;
             assign s_rx_cfg_stream_id[CH_ID_RX_UART+g_uart] = 'h0;
@@ -497,7 +498,10 @@ module udma_subsystem
                 .data_rx_datasize_o  ( s_rx_ch_datasize[CH_ID_RX_UART+g_uart]    ),
                 .data_rx_o           ( s_rx_ch_data[CH_ID_RX_UART+g_uart]        ),
                 .data_rx_valid_o     ( s_rx_ch_valid[CH_ID_RX_UART+g_uart]       ),
-                .data_rx_ready_i     ( s_rx_ch_ready[CH_ID_RX_UART+g_uart]       )
+                .data_rx_ready_i     ( s_rx_ch_ready[CH_ID_RX_UART+g_uart]       ),
+
+                .rx_char_event_o     ( s_uart_char[g_uart]                       ),
+                .err_event_o         ( s_uart_err[g_uart]                        )
             );
         end
     endgenerate

--- a/rtl/udma_subsystem/udma_subsystem.sv
+++ b/rtl/udma_subsystem/udma_subsystem.sv
@@ -135,11 +135,7 @@ module udma_subsystem
     localparam N_FILTER   = 1;
     localparam N_CH_HYPER = 8;
     localparam N_FPGA     = 0;
-`ifdef PULP_TRAINING
-    localparam N_EXT_PER  = 1;
-`else
     localparam N_EXT_PER  = 0;
-`endif
 
     localparam N_RX_CHANNELS =   N_SPI + N_HYPER + N_MRAM + N_JTAG + N_SDIO + N_UART + N_I2C + N_I2S + N_CAM + 2*N_CSI2 + N_FPGA + N_EXT_PER + N_CH_HYPER;
     localparam N_TX_CHANNELS = 2*N_SPI + N_HYPER + N_MRAM + N_JTAG + N_SDIO + N_UART + 2*N_I2C + N_I2S + N_FPGA + N_EXT_PER + N_CH_HYPER;
@@ -1079,65 +1075,4 @@ module udma_subsystem
         //.debug_hyper_phy_state_o ( debug_hyper_phy_state_o                          )
     );
 
-
-`ifdef PULP_TRAINING
-    //PER_ID 9
-    assign s_events[4*PER_ID_EXT_PER]            = s_rx_ch_events[CH_ID_RX_EXT_PER];
-    assign s_events[4*PER_ID_EXT_PER+1]          = s_tx_ch_events[CH_ID_TX_EXT_PER];
-    assign s_events[4*PER_ID_EXT_PER+2]          = 1'b0;
-    assign s_events[4*PER_ID_EXT_PER+3]          = 1'b0;
-
-    assign s_rx_cfg_stream[CH_ID_RX_EXT_PER]     = 'h0;
-    assign s_rx_cfg_stream_id[CH_ID_RX_EXT_PER]  = 'h0;
-    assign s_rx_ch_destination[CH_ID_RX_EXT_PER] = 'h0;
-    assign s_tx_ch_destination[CH_ID_TX_EXT_PER] = 'h0;
-
-    udma_external_per_wrapper #(
-      .L2_AWIDTH_NOAL(L2_AWIDTH_NOAL),
-      .TRANS_SIZE(TRANS_SIZE)
-    ) i_external_per (
-        .sys_clk_i           ( s_clk_periphs_core[PER_ID_EXT_PER]    ),
-        .periph_clk_i        ( s_clk_periphs_per[PER_ID_EXT_PER]     ),
-        .rstn_i              ( sys_resetn_i                          ),
-
-        .cfg_data_i          ( s_periph_data_to                      ),
-        .cfg_addr_i          ( s_periph_addr                         ),
-        .cfg_valid_i         ( s_periph_valid[PER_ID_EXT_PER]        ),
-        .cfg_rwn_i           ( s_periph_rwn                          ),
-        .cfg_ready_o         ( s_periph_ready[PER_ID_EXT_PER]        ),
-        .cfg_data_o          ( s_periph_data_from[PER_ID_EXT_PER]    ),
-
-        .cfg_rx_startaddr_o  ( s_rx_cfg_startaddr[CH_ID_RX_EXT_PER]  ),
-        .cfg_rx_size_o       ( s_rx_cfg_size[CH_ID_RX_EXT_PER]       ),
-        .cfg_rx_continuous_o ( s_rx_cfg_continuous[CH_ID_RX_EXT_PER] ),
-        .cfg_rx_en_o         ( s_rx_cfg_en[CH_ID_RX_EXT_PER]         ),
-        .cfg_rx_clr_o        ( s_rx_cfg_clr[CH_ID_RX_EXT_PER]        ),
-        .cfg_rx_en_i         ( s_rx_ch_en[CH_ID_RX_EXT_PER]          ),
-        .cfg_rx_pending_i    ( s_rx_ch_pending[CH_ID_RX_EXT_PER]     ),
-        .cfg_rx_curr_addr_i  ( s_rx_ch_curr_addr[CH_ID_RX_EXT_PER]   ),
-        .cfg_rx_bytes_left_i ( s_rx_ch_bytes_left[CH_ID_RX_EXT_PER]  ),
-
-        .cfg_tx_startaddr_o  ( s_tx_cfg_startaddr[CH_ID_TX_EXT_PER]  ),
-        .cfg_tx_size_o       ( s_tx_cfg_size[CH_ID_TX_EXT_PER]       ),
-        .cfg_tx_continuous_o ( s_tx_cfg_continuous[CH_ID_TX_EXT_PER] ),
-        .cfg_tx_en_o         ( s_tx_cfg_en[CH_ID_TX_EXT_PER]         ),
-        .cfg_tx_clr_o        ( s_tx_cfg_clr[CH_ID_TX_EXT_PER]        ),
-        .cfg_tx_en_i         ( s_tx_ch_en[CH_ID_TX_EXT_PER]          ),
-        .cfg_tx_pending_i    ( s_tx_ch_pending[CH_ID_TX_EXT_PER]     ),
-        .cfg_tx_curr_addr_i  ( s_tx_ch_curr_addr[CH_ID_TX_EXT_PER]   ),
-        .cfg_tx_bytes_left_i ( s_tx_ch_bytes_left[CH_ID_TX_EXT_PER]  ),
-
-        .data_tx_req_o       ( s_tx_ch_req[CH_ID_TX_EXT_PER]         ),
-        .data_tx_gnt_i       ( s_tx_ch_gnt[CH_ID_TX_EXT_PER]         ),
-        .data_tx_datasize_o  ( s_tx_ch_datasize[CH_ID_TX_EXT_PER]    ),
-        .data_tx_i           ( s_tx_ch_data[CH_ID_TX_EXT_PER]        ),
-        .data_tx_valid_i     ( s_tx_ch_valid[CH_ID_TX_EXT_PER]       ),
-        .data_tx_ready_o     ( s_tx_ch_ready[CH_ID_TX_EXT_PER]       ),
-
-        .data_rx_datasize_o  ( s_rx_ch_datasize[CH_ID_RX_EXT_PER]    ),
-        .data_rx_o           ( s_rx_ch_data[CH_ID_RX_EXT_PER]        ),
-        .data_rx_valid_o     ( s_rx_ch_valid[CH_ID_RX_EXT_PER]       ),
-        .data_rx_ready_i     ( s_rx_ch_ready[CH_ID_RX_EXT_PER]       )
-    );
-`endif
 endmodule


### PR DESCRIPTION
* Update RI5CY to CV32E40P
* Wire up uart char and error events
* Remove ` PULP_TRAINING`  references
* Propagate ` USE_XPULP` for enabling PULP extensions