### PR TITLE
Fixes for synthesis

### DIFF
--- a/rtl/pulp_soc/soc_interconnect.sv
+++ b/rtl/pulp_soc/soc_interconnect.sv
@@ -89,7 +89,7 @@ module soc_interconnect
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-    XBAR_TCDM_BUS l2_demux_slaves[NR_MASTER_PORTS*3-1:0]();
+    XBAR_TCDM_BUS l2_demux_slaves[NR_MASTER_PORTS*3]();
     for (genvar i = 0; i < NR_MASTER_PORTS; i++) begin : gen_l2_demux
         `TCDM_ASSIGN_INTF(l2_demux_2_axi_bridge[i], l2_demux_slaves[3*i + 0]);
         `TCDM_ASSIGN_INTF(l2_demux_2_contiguous_xbar[i], l2_demux_slaves[3*i + 1]);
@@ -105,7 +105,7 @@ module soc_interconnect
                                   .test_en_i,
                                   .addr_map_rules(addr_space_l2_demux),
                                   .master_port(master_ports[i]),
-                                  .slave_ports(l2_demux_slaves[3*(i+1)-1:3*i])
+                                  .slave_ports(l2_demux_slaves[3*i+:3])
                                   );
     end
 
@@ -116,7 +116,7 @@ module soc_interconnect
     // interleaved memory region.                                                                               //
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////
     XBAR_TCDM_BUS master_ports_interleaved_only_checked[NR_MASTER_PORTS_INTERLEAVED_ONLY]();
-    XBAR_TCDM_BUS err_demux_slaves[NR_MASTER_PORTS_INTERLEAVED_ONLY*2-1:0]();
+    XBAR_TCDM_BUS err_demux_slaves[NR_MASTER_PORTS_INTERLEAVED_ONLY*2]();
     for (genvar i = 0; i < NR_MASTER_PORTS_INTERLEAVED_ONLY; i++) begin : gen_interleaved_only_err_checkers
         `TCDM_ASSIGN_INTF(master_ports_interleaved_only_checked[i], err_demux_slaves[2*i + 1]);
         // Workaround for genus (doesn't seem to like references interface
@@ -135,7 +135,7 @@ module soc_interconnect
           .test_en_i,
           .addr_map_rules ( addr_space_interleaved           ),
           .master_port    ( master_ports_interleaved_only[i] ),
-          .slave_ports    ( err_demux_slaves[2*i+1:2*i]      )
+          .slave_ports    ( err_demux_slaves[2*i+:2]         )
         );
         tcdm_error_slave #(
           .ERROR_RESPONSE(32'hBADACCE5)

--- a/rtl/pulp_soc/soc_interconnect.sv
+++ b/rtl/pulp_soc/soc_interconnect.sv
@@ -105,7 +105,7 @@ module soc_interconnect
                                   .test_en_i,
                                   .addr_map_rules(addr_space_l2_demux),
                                   .master_port(master_ports[i]),
-                                  .slave_ports(l2_demux_slaves[3*i+:3])
+                                  .slave_ports(l2_demux_slaves[3*i:3*(i+1)-1])
                                   );
     end
 
@@ -135,7 +135,7 @@ module soc_interconnect
           .test_en_i,
           .addr_map_rules ( addr_space_interleaved           ),
           .master_port    ( master_ports_interleaved_only[i] ),
-          .slave_ports    ( err_demux_slaves[2*i+:2]         )
+          .slave_ports    ( err_demux_slaves[2*i:2*(i+1)-1]  )
         );
         tcdm_error_slave #(
           .ERROR_RESPONSE(32'hBADACCE5)

--- a/rtl/pulp_soc/soc_peripherals.sv
+++ b/rtl/pulp_soc/soc_peripherals.sv
@@ -289,13 +289,6 @@ module soc_peripherals #(
         .stdout_master       ( s_stdout_bus       )
     );
 
-    `ifdef SYNTHESIS
-        assign s_stdout_bus.pready  = 'h0;
-        assign s_stdout_bus.pslverr = 'h0;
-        assign s_stdout_bus.prdata  = 'h0;
-    `endif
-
-
     /////////////////////////////////////////////////////////////////////////
     //  █████╗ ██████╗ ██████╗     ███████╗██╗     ██╗         ██╗███████╗ //
     // ██╔══██╗██╔══██╗██╔══██╗    ██╔════╝██║     ██║         ██║██╔════╝ //

--- a/rtl/pulp_soc/tcdm_demux.sv
+++ b/rtl/pulp_soc/tcdm_demux.sv
@@ -34,7 +34,7 @@ module tcdm_demux
      input logic                                  test_en_i,
      input addr_map_rule_t[NR_ADDR_MAP_RULES-1:0] addr_map_rules,
      XBAR_TCDM_BUS.Slave                          master_port,
-     XBAR_TCDM_BUS.Master                         slave_ports[NR_OUTPUTS-1:0]
+     XBAR_TCDM_BUS.Master                         slave_ports[NR_OUTPUTS]
      );
     // Do **not** change. The TCDM interface uses hardcoded bus widths so we cannot just change them here.
     localparam int unsigned BE_WIDTH = 2;

--- a/rtl/pulp_soc/tcdm_demux.sv
+++ b/rtl/pulp_soc/tcdm_demux.sv
@@ -34,7 +34,7 @@ module tcdm_demux
      input logic                                  test_en_i,
      input addr_map_rule_t[NR_ADDR_MAP_RULES-1:0] addr_map_rules,
      XBAR_TCDM_BUS.Slave                          master_port,
-     XBAR_TCDM_BUS.Master                         slave_ports[NR_OUTPUTS]
+     XBAR_TCDM_BUS.Master                         slave_ports[NR_OUTPUTS-1:0]
      );
     // Do **not** change. The TCDM interface uses hardcoded bus widths so we cannot just change them here.
     localparam int unsigned BE_WIDTH = 2;


### PR DESCRIPTION
Two issues cropped up when running through synopsys:
- double assigned signals (grounded `stdout_bus` in `soc_peripherals`) with `TARGET_SYNTHESIS`
- invalid symbol for array interface assignments in gen loop (See also https://github.com/pulp-platform/pulpissimo/issues/332)