### PR TITLE
Align ibex to cv32e40p

### DIFF
--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -244,13 +244,6 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
 
     assign supervisor_mode_o = 1'b1;
 
-    always_comb begin : gen_core_irq_x
-        core_irq_x = '0;
-        if (core_irq_req) begin
-            core_irq_x[core_irq_id] = 1'b1;
-        end
-    end
-
     end else begin: FC_CORE
     assign boot_addr = boot_addr_i & 32'hFFFFFF00; // RI5CY expects 0x80 offset, Ibex expects 0x00 offset (adds reset offset 0x80 internally)
 `ifdef VERILATOR
@@ -313,6 +306,7 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
         .irq_fast_i            ( 15'b0             ),
         .irq_nm_i              ( 1'b0              ),
 
+        // Ibex supports 32 additional fast interrupts and reads the interrupt lines directly.
         .irq_x_i               ( core_irq_x        ),
         .irq_x_ack_o           ( core_irq_ack      ),
         .irq_x_ack_id_o        ( core_irq_ack_id   ),
@@ -328,15 +322,7 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
     );
 
     assign supervisor_mode_o = 1'b1;
-    // Ibex supports 32 additional fast interrupts and reads the interrupt lines directly.
-    // Convert ID back to interrupt lines
-    always_comb begin : gen_core_irq_x
-        core_irq_x = '0;
-        if (core_irq_req) begin
-            core_irq_x[core_irq_id] = 1'b1;
-        end
-    end
-
+ 
     end
     endgenerate
 
@@ -358,6 +344,14 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
         .fetch_en_o         ( fetch_en_eu        ),
         .apb_slave          ( apb_slave_eu       )
     );
+
+    // Convert ID back to interrupt lines
+    always_comb begin : gen_core_irq_x
+        core_irq_x = '0;
+        if (core_irq_req) begin
+            core_irq_x[core_irq_id] = 1'b1;
+        end
+    end
 
 
     if(USE_HWPE) begin : fc_hwpe_gen

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -72,7 +72,7 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
     logic [31:0] core_irq_x;
 
     // Signals for OBI-PULP conversion
-    logic        pulp_instr_req;
+    logic        pulp_instr_req, pulp_data_req;
 
     // Boot address, core id, cluster id, fethc enable and core_status
     logic [31:0] boot_addr        ;
@@ -117,7 +117,7 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
     //********************************************************
     //************ CORE DEMUX (TCDM vs L2) *******************
     //********************************************************
-    assign l2_data_master.req    = core_data_req;
+    assign l2_data_master.req    = pulp_data_req;
     assign l2_data_master.add    = core_data_addr;
     assign l2_data_master.wen    = ~core_data_we;
     assign l2_data_master.wdata  = core_data_wdata;
@@ -127,6 +127,15 @@ module fc_subsystem import cv32e40p_apu_core_pkg::*; #(
     assign core_data_rdata       = l2_data_master.r_rdata;
     assign core_data_err         = l2_data_master.r_opc;
 
+    // OBI-PULP adapter
+    obi_pulp_adapter i_obi_pulp_adapter_data (
+        .rst_ni       (rst_ni),
+        .clk_i        (clk_i),
+        .core_req_i   (core_data_req),
+        .mem_gnt_i    (core_data_gnt),
+        .mem_rvalid_i (core_data_rvalid),
+        .mem_req_o    (pulp_data_req)
+    );
 
     assign l2_instr_master.req   = pulp_instr_req;
     assign l2_instr_master.add   = core_instr_addr;


### PR DESCRIPTION
With the update to cv32e40p, several changes which are directly compatible with ibex were implemented. This PR aligns the implementations for the OBI adapter and interrupt vector.