### PR TITLE
tcdm_err_slave: stall r_opc for 1 cycle

### DIFF
--- a/rtl/pulp_soc/tcdm_error_slave.sv
+++ b/rtl/pulp_soc/tcdm_error_slave.sv
@@ -32,7 +32,7 @@ module tcdm_error_slave #(
     logic         error_valid_d, error_valid_q;
     assign slave.gnt = slave.req;
     assign error_valid_d = slave.req;
-    assign slave.r_opc = slave.req;
+    assign slave.r_opc = error_valid_q;
     assign slave.r_rdata = ERROR_RESPONSE;
     assign slave.r_valid = error_valid_q;
 


### PR DESCRIPTION
The r_opc signal should come with the response signal (r_valid), a cycle after the req/gnt handshake. This change fixes a timing loop when using ibex as FC.