### PR TITLE
Fix type of C_DIV for cv32e40p_fp_wrapper

### DIFF
--- a/rtl/fc/cv32e40p_fp_wrapper.sv
+++ b/rtl/fc/cv32e40p_fp_wrapper.sv
@@ -54,7 +54,7 @@ assign {fpu_vec_op, fpu_op_mod, fpu_op}                     = apu_op_i;
 
 assign {fpu_int_fmt, fpu_src_fmt, fpu_dst_fmt, fp_rnd_mode} = apu_flags_i;
 
-localparam C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
+localparam fpnew_pkg::unit_type_t C_DIV = FP_DIVSQRT ? fpnew_pkg::MERGED : fpnew_pkg::DISABLED;
 
 // -----------
 // FPU Config


### PR DESCRIPTION
Required for synthesis with Vivado 2020.2

This is the same error as in pulp-platform/cv32e40p#2