### PR TITLE
Align FC_EVENT_POS of soc_event_generator to position in s_events vector

### DIFF
--- a/rtl/pulp_soc/soc_peripherals.sv
+++ b/rtl/pulp_soc/soc_peripherals.sv
@@ -625,7 +625,7 @@ module soc_peripherals #(
         .APB_EVNT_NUM   ( 8              ),
         .PER_EVNT_NUM   ( 160            ),
         .EVNT_WIDTH     ( EVNT_WIDTH     ),
-        .FC_EVENT_POS   ( 7              )
+        .FC_EVENT_POS   ( 140            )
     ) u_evnt_gen (
         .HCLK             ( clk_i                      ),
         .HRESETn          ( rst_ni                     ),


### PR DESCRIPTION
This pull request is in reference to https://github.com/pulp-platform/pulpissimo/issues/353: In line [217](https://github.com/pulp-platform/pulp_soc/blob/master/rtl/pulp_soc/soc_peripherals.sv#L217) the fc_hwpe_events are connected to indicies 140+141. 

Thus, the FC_EVENT_POS for the event_generator should be aligned to this. Position 7 is part of the UART in the UDMA subsystem as far as I can tell.