### PR TITLE
soc_event_generator: preserve r_err set on concurrent APB read race

### DIFF
--- a/rtl/pulp_soc/soc_event_generator.sv
+++ b/rtl/pulp_soc/soc_event_generator.sv
@@ -206,9 +206,6 @@ module soc_event_generator #(
       r_err             =  'h0;
     end
     else begin
-      for (int i=0;i<EVNT_NUM;i++)
-        if(s_err[i])
-          r_err[i] = 1'b1;
       r_apb_events     =  'h0;
       if (PSEL && PENABLE && PWRITE) begin
         case (s_apb_addr)
@@ -341,6 +338,12 @@ module soc_event_generator #(
               r_err[255:224] = 'h0;
         endcase // s_apb_addr
       end
+      // Sticky-set per-source error bits AFTER any APB read-clear so
+      // that an event firing on the same cycle as the read survives.
+      // Set wins over clear in the same-cycle race.
+      for (int i=0;i<EVNT_NUM;i++)
+        if(s_err[i])
+          r_err[i] = 1'b1;
     end
   end //always
 


### PR DESCRIPTION
Hi there!

soc_event_generator could drop a newly raised r_err bit when a queue overflow occurs on the same HCLK edge as an APB read-clear of REG_ERR_0. The set loop runs first, but the later blocking read-clear assignment overwrites it, and software never sees the new error in PRDATA or later reads.

Move the per-source r_err set loop after the APB read-clear branch so same-cycle set-after-clear preserves sticky error bits

Thanks!
Flavien